### PR TITLE
Capitalize AS keyword in builder stage for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
The change replaces the lowercase 'as' with uppercase 'AS' in the Dockerfile's builder stage declaration. This follows Docker's convention of using uppercase for all commands and keywords, improving readability and maintaining consistency with standard Dockerfile practices.