### PR TITLE
Add PR reference to TODO comment about LabelNames replacement

### DIFF
--- a/pkg/metadata_query/labels.go
+++ b/pkg/metadata_query/labels.go
@@ -28,7 +28,7 @@ type LabelNamesArguments struct {
 }
 
 type LabelNamesResult struct {
-	// TODO: replace []string with model.LabelNames ?
+	// TODO: replace []string with model.LabelNames ? https://github.com/prometheus/client_golang/pull/1850
 	LabelNames []string    `json:"names" jsonschema:"Names is a list of string label names."`
 	Warnings   v1.Warnings `json:"warnings,omitempty"`
 }

--- a/pkg/metadata_query/labels.go
+++ b/pkg/metadata_query/labels.go
@@ -28,7 +28,7 @@ type LabelNamesArguments struct {
 }
 
 type LabelNamesResult struct {
-	// TODO: replace []string with model.LabelNames ? https://github.com/prometheus/client_golang/pull/1850
+	// TODO: Replace []string with model.LabelNames (see https://github.com/prometheus/client_golang/pull/1850).
 	LabelNames []string    `json:"names" jsonschema:"Names is a list of string label names."`
 	Warnings   v1.Warnings `json:"warnings,omitempty"`
 }


### PR DESCRIPTION
[Explanation: Added GitHub PR link (prometheus/client_golang#1850) to existing TODO comment to provide context for future type replacement from []string to model.LabelNames]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated a comment to include a reference link for additional context. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->