### PR TITLE
Add version info injection at build time and -version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,19 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+
+    # Custom ldflags.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
+    # and https://pkg.go.dev/cmd/link
+    #
+    # Default: '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'.
+    # Templates: allowed.
+    ldflags:
+      - -s
+      - -w
+      - -X {{ .ModulePath }}/pkg/version.Number={{ .Version }}
+      - -X {{ .ModulePath }}/pkg/version.GitCommit={{ .Commit }}
+      - -X {{ .ModulePath }}/pkg/version.BuildDate={{ .Date }}
     
     # GOOS list to build for.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Get version information from git and system
+VERSION ?= 0.1.1
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
+BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Package and binary name
+BINARY := pmcp
+PACKAGE := github.com/yshngg/pmcp
+
+# Build flags
+LDFLAGS := -s -w
+LDFLAGS += -X $(PACKAGE)/pkg/version.Number=$(VERSION)
+LDFLAGS += -X $(PACKAGE)/pkg/version.GitCommit=$(GIT_COMMIT)
+LDFLAGS += -X $(PACKAGE)/pkg/version.BuildDate=$(BUILD_DATE)
+
+# Default target
+all: build
+
+# Build the binary
+build:
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) main.go
+
+# Install the binary
+install:
+	go install -ldflags "$(LDFLAGS)" .
+
+# Clean build artifacts
+clean:
+	rm -f $(BINARY)
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all     - Build the binary (default)"
+	@echo "  build   - Build the binary"
+	@echo "  install - Install the binary"
+	@echo "  clean   - Remove build artifacts"
+	@echo "  help    - Show this help"
+
+.PHONY: all build install clean help

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # Package and binary name
 BINARY := pmcp
-PACKAGE := github.com/yshngg/pmcp
+PACKAGE := $(shell go list -m)
 
 # Build flags
 LDFLAGS := -s -w

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	expressionquery "github.com/yshngg/pmcp/pkg/expression_query"
 	metadataquery "github.com/yshngg/pmcp/pkg/metadata_query"
 	"github.com/yshngg/pmcp/pkg/prometheus/client"
+	"github.com/yshngg/pmcp/pkg/version"
 )
 
 // Schema is the identifier for the Prometheus schema.
@@ -25,6 +26,8 @@ var (
 	mcpAddr = flag.String("mcp-addr", "localhost:8080", "The address of the MCP server to listen on.")
 	// transportType specifies the transport mechanism (stdio, sse, or http).
 	transportType = flag.String("transport", "stdio", "Transport type (stdio, sse or http).\nThe mechanisms that handle the underlying communication between clients and servers.")
+	// printVersion prints the version and exit.
+	printVersion = flag.Bool("version", false, "Print the version and exit.")
 )
 
 func init() {
@@ -36,9 +39,14 @@ func init() {
 // It sets up the MCP server, registers Prometheus query tools, and starts the server
 // using the specified transport (stdio, http, or sse).
 func main() {
+	if *printVersion {
+		fmt.Println(version.Info)
+		os.Exit(0)
+	}
+
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "pmcp",
-		Version: "0.2.0-alpha",
+		Version: version.Info.Number,
 	}, nil)
 
 	if err := AddTools(server); err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,6 +25,9 @@ var (
 )
 
 func init() {
+	if len(Number) == 0 {
+		return
+	}
 	Info = info{
 		Number:    Number,
 		GitCommit: GitCommit,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,12 +25,9 @@ var (
 )
 
 func init() {
-	if len(Number) == 0 {
-		return
-	}
-	Info = info{
-		Number:    Number,
-		GitCommit: GitCommit,
-		BuildDate: BuildDate,
+	if len(Number) != 0 {
+		Info.Number = Number
+		Info.GitCommit = GitCommit
+		Info.BuildDate = BuildDate
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,33 @@
+package version
+
+import "fmt"
+
+type info struct {
+	Number    string
+	GitCommit string
+	BuildDate string
+}
+
+func (i info) String() string {
+	return fmt.Sprintf("PMCP Version: v%s\nGit Commit: %s\nBuild Date: %s", i.Number, i.GitCommit, i.BuildDate)
+}
+
+var (
+	Number    string
+	GitCommit string
+	BuildDate string
+
+	Info = info{
+		Number:    "0.1.0",
+		GitCommit: "HEAD",
+		BuildDate: "2006-01-02T15:04:05Z07:00",
+	}
+)
+
+func init() {
+	Info = info{
+		Number:    Number,
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+	}
+}


### PR DESCRIPTION
The changes introduce version information injection during the build process and add a -version flag to display it. 

Key updates:
1. Added ldflags configuration in .goreleaser.yaml to inject version metadata
2. Created Makefile with version-aware build targets
3. Implemented version package to store build metadata
4. Added -version flag in main.go to display version info
5. Updated server to use injected version number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line flag to display the application's version information.
  * Introduced embedded version metadata (version number, Git commit, build date) in the application binary.
  * Provided a help command for make-based build and installation tasks.

* **Chores**
  * Added a Makefile to streamline building, installing, and cleaning the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->