### PR TITLE
Move build args to global scope and redeclare in build age for better flexibility

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -76,9 +76,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            - VERSION_NUMBER=${{ steps.build-args.outputs.VERSION_NUMBER }}
-            - GIT_COMMIT=${{ steps.build-args.outputs.GIT_COMMIT }}
-            - BUILD_DATE=${{ steps.build-args.outputs.BUILD_DATE }}
+            VERSION_NUMBER=${{ steps.build-args.outputs.VERSION_NUMBER }}
+            GIT_COMMIT=${{ steps.build-args.outputs.GIT_COMMIT }}
+            BUILD_DATE=${{ steps.build-args.outputs.BUILD_DATE }}
           platforms: ${{ matrix.platform }}
           context: .
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 # syntax=docker/dockerfile:1
 
+ARG VERSION_NUMBER=0.0.0-dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build stage
 FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG VERSION_NUMBER=0.0.0-dev
-ARG GIT_COMMIT=unknown
-ARG BUILD_DATE=unknown
+ARG VERSION_NUMBER
+ARG GIT_COMMIT
+ARG BUILD_DATE
 
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build configuration to ensure versioning and build metadata are consistently available during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->