### PR TITLE
Set development version to 0.1.0-dev across build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Get version information from git and system
-VERSION ?= 0.1.1
+VERSION ?= 0.1.0-dev
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ var (
 	BuildDate string
 
 	Info = info{
-		Number:    "0.1.0",
+		Number:    "0.1.0-dev",
 		GitCommit: "HEAD",
 		BuildDate: "2006-01-02T15:04:05Z07:00",
 	}


### PR DESCRIPTION
The changes update the version identifier to "0.1.0-dev" in both the Makefile and version.go files, establishing a consistent development version marker throughout the build system. This modification prepares the codebase for ongoing development work by clearly distinguishing this as a pre-release version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default version string displayed in the application to "0.1.0-dev".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->