### PR TITLE
Add Alertmanager Discovery feature to monitor Prometheus alertmanager state

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ pmcp --prom-addr="http://localhost:9090" --transport=sse --mcp-addr="localhost:8
 * **Target Discovery**: Overview of currently discovered Prometheus targets and their statuses.
 * **Alert Query**: Get a list of all active alerts.
 * **Rule Query**: Get a list of alerting and recording rules that are currently loaded.
+* **Alertmanager Discovery**: Get an overview of the current state of the Prometheus alertmanager discovery.
 * **Health Check**: Verify if Prometheus is responding.
 * **Readiness Check**: Determine if Prometheus is ready to serve queries.
 * **Reload**: Trigger configuration and rule file reload.

--- a/pkg/alertmanager_discover/alertmanager_discovery.go
+++ b/pkg/alertmanager_discover/alertmanager_discovery.go
@@ -13,12 +13,8 @@ type AlertmanagerDiscoverParams struct{}
 type AlertmanagerDiscoverResult = v1.AlertManagersResult
 
 func (d *alertmanagerDiscoverer) AlertmanagerDiscoverHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[AlertmanagerDiscoverParams]) (*mcp.CallToolResultFor[AlertmanagerDiscoverResult], error) {
-	var (
-		result AlertmanagerDiscoverResult
-		err    error
-	)
-
-	if result, err = d.API.AlertManagers(ctx); err != nil {
+	result, err := d.API.AlertManagers(ctx)
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/alertmanager_discover/alertmanager_discovery.go
+++ b/pkg/alertmanager_discover/alertmanager_discovery.go
@@ -1,0 +1,34 @@
+package alertmanagerdiscover
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type AlertmanagerDiscoverParams struct{}
+
+type AlertmanagerDiscoverResult = v1.AlertManagersResult
+
+func (d *alertmanagerDiscoverer) AlertmanagerDiscoverHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[AlertmanagerDiscoverParams]) (*mcp.CallToolResultFor[AlertmanagerDiscoverResult], error) {
+	var (
+		result AlertmanagerDiscoverResult
+		err    error
+	)
+
+	if result, err = d.API.AlertManagers(ctx); err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[AlertmanagerDiscoverResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/alertmanager_discover/discover.go
+++ b/pkg/alertmanager_discover/discover.go
@@ -1,0 +1,22 @@
+package alertmanagerdiscover
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/pmcp/pkg/prometheus/api"
+)
+
+type AlertmanagerDiscoverer interface {
+	AlertmanagerDiscoverHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[AlertmanagerDiscoverParams]) (*mcp.CallToolResultFor[AlertmanagerDiscoverResult], error)
+}
+
+func NewAlertmanagerDiscoverer(api api.PrometheusAPI) AlertmanagerDiscoverer {
+	return &alertmanagerDiscoverer{API: api}
+}
+
+type alertmanagerDiscoverer struct {
+	API api.PrometheusAPI
+}
+
+var _ AlertmanagerDiscoverer = &alertmanagerDiscoverer{}

--- a/pkg/bind/tool.go
+++ b/pkg/bind/tool.go
@@ -3,6 +3,7 @@ package bind
 import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	alertquery "github.com/yshngg/pmcp/pkg/alert_query"
+	alertmanagerdiscover "github.com/yshngg/pmcp/pkg/alertmanager_discover"
 	expressionquery "github.com/yshngg/pmcp/pkg/expression_query"
 	"github.com/yshngg/pmcp/pkg/manage"
 	metadataquery "github.com/yshngg/pmcp/pkg/metadata_query"
@@ -86,6 +87,16 @@ func (b *binder) addTools() {
 			Name:        "Alert Query",
 			Description: "Get a list of all active alerts.",
 		}, alertQuerier.AlertQueryHandler)
+	}
+
+	// Alertmanagers
+	// An overview of the current state of the Prometheus alertmanager discovery.
+	{
+		alertmanagerDiscoverer := alertmanagerdiscover.NewAlertmanagerDiscoverer(b.api)
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "Alertmanager Discovery",
+			Description: "Get an overview of the current state of the Prometheus alertmanager discovery.",
+		}, alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
 	}
 
 	// Management API


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an "Alertmanager Discovery" tool, allowing users to view the current state of Prometheus Alertmanager discovery directly within the application.

* **Documentation**
  * Updated the README to include the new "Alertmanager Discovery" tool in the list of available features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->