### PR TITLE
Add multiple status exposure endpoints for Prometheus monitoring capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ pmcp --prom-addr="http://localhost:9090" --transport=sse --mcp-addr="localhost:8
 * **Alert Query**: Get a list of all active alerts.
 * **Rule Query**: Get a list of alerting and recording rules that are currently loaded.
 * **Alertmanager Discovery**: Get an overview of the current state of the Prometheus alertmanager discovery.
+* **Config**: Return currently loaded configuration file.
+* **Flags**: Return flag values that Prometheus was configured with.
+* **Runtime Information**: Return various runtime information properties about the Prometheus server.
+* **Build Information**: Return various build information properties about the Prometheus server.
+* **TSDB Stats**: Return various cardinality statistics about the Prometheus TSDB.
+* **WAL Replay Stats**: Return information about the WAL replay.
 * **Health Check**: Verify if Prometheus is responding.
 * **Readiness Check**: Determine if Prometheus is ready to serve queries.
 * **Reload**: Trigger configuration and rule file reload.

--- a/pkg/bindingblocks/tools.go
+++ b/pkg/bindingblocks/tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yshngg/pmcp/pkg/manage"
 	"github.com/yshngg/pmcp/pkg/metadataquery"
 	"github.com/yshngg/pmcp/pkg/rulequery"
+	"github.com/yshngg/pmcp/pkg/statusexpose"
 	"github.com/yshngg/pmcp/pkg/targetdiscover"
 )
 
@@ -97,6 +98,41 @@ func (b *binder) addTools() {
 			Name:        "Alertmanager Discovery",
 			Description: "Get an overview of the current state of the Prometheus alertmanager discovery.",
 		}, alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
+	}
+
+	// Status
+	// Expose current Prometheus configuration.
+	{
+		statusExposer := statusexpose.NewStatusExposer(b.api)
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "Config",
+			Description: "Return currently loaded configuration file.",
+		}, statusExposer.ConfigExposeHandler)
+
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "Flags",
+			Description: "Return flag values that Prometheus was configured with.",
+		}, statusExposer.FlagsExposeHandler)
+
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "Runtime Information",
+			Description: "Return various runtime information properties about the Prometheus server.",
+		}, statusExposer.RuntimeInformationExposeHandler)
+
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "Build Information",
+			Description: "Return various build information properties about the Prometheus server.",
+		}, statusExposer.BuildInformationExposeHandler)
+
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "TSDB Stats",
+			Description: "Return various cardinality statistics about the Prometheus TSDB.",
+		}, statusExposer.TSDBStatsExposeHandler)
+
+		mcp.AddTool(b.server, &mcp.Tool{
+			Name:        "WAL Replay Stats",
+			Description: "Return information about the WAL replay.",
+		}, statusExposer.TSDBStatsExposeHandler)
 	}
 
 	// Management API

--- a/pkg/statusexpose/build_information.go
+++ b/pkg/statusexpose/build_information.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type BuildInformationExposeParams struct{}
+
+type BuildInformationExposeResult = v1.BuildinfoResult
+
+func (e *statusExposer) BuildInformationExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[BuildInformationExposeParams]) (*mcp.CallToolResultFor[BuildInformationExposeResult], error) {
+	result, err := e.API.Buildinfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[BuildInformationExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/statusexpose/config.go
+++ b/pkg/statusexpose/config.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type ConfigExposeParams struct{}
+
+type ConfigExposeResult = v1.ConfigResult
+
+func (e *statusExposer) ConfigExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[ConfigExposeParams]) (*mcp.CallToolResultFor[ConfigExposeResult], error) {
+	result, err := e.API.Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[ConfigExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/statusexpose/expose.go
+++ b/pkg/statusexpose/expose.go
@@ -1,0 +1,29 @@
+package statusexpose
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/pmcp/pkg/prometheus/api"
+)
+
+type StatusExposer interface {
+	ConfigExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[ConfigExposeParams]) (*mcp.CallToolResultFor[ConfigExposeResult], error)
+	FlagsExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[FlagsExposeParams]) (*mcp.CallToolResultFor[FlagsExposeResult], error)
+	RuntimeInformationExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[RuntimeInformationExposeParams]) (*mcp.CallToolResultFor[RuntimeInformationExposeResult], error)
+	BuildInformationExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[BuildInformationExposeParams]) (*mcp.CallToolResultFor[BuildInformationExposeResult], error)
+	TSDBStatsExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[TSDBStatsExposeParams]) (*mcp.CallToolResultFor[TSDBStatsExposeResult], error)
+	WALReplayStatsExposeHandler(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[WALReplayStatsExposeParams]) (*mcp.CallToolResultFor[WALReplayStatsExposeResult], error)
+}
+
+func NewStatusExposer(api api.PrometheusAPI) StatusExposer {
+	return &statusExposer{
+		API: api,
+	}
+}
+
+type statusExposer struct {
+	API api.PrometheusAPI
+}
+
+var _ StatusExposer = &statusExposer{}

--- a/pkg/statusexpose/flags.go
+++ b/pkg/statusexpose/flags.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type FlagsExposeParams struct{}
+
+type FlagsExposeResult = v1.FlagsResult
+
+func (e *statusExposer) FlagsExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[FlagsExposeParams]) (*mcp.CallToolResultFor[FlagsExposeResult], error) {
+	result, err := e.API.Flags(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[FlagsExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/statusexpose/runtime_information.go
+++ b/pkg/statusexpose/runtime_information.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type RuntimeInformationExposeParams struct{}
+
+type RuntimeInformationExposeResult = v1.RuntimeinfoResult
+
+func (e *statusExposer) RuntimeInformationExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[RuntimeInformationExposeParams]) (*mcp.CallToolResultFor[RuntimeInformationExposeResult], error) {
+	result, err := e.API.Runtimeinfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[RuntimeInformationExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/statusexpose/tsdb_stats.go
+++ b/pkg/statusexpose/tsdb_stats.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type TSDBStatsExposeParams struct{}
+
+type TSDBStatsExposeResult = v1.TSDBResult
+
+func (e *statusExposer) TSDBStatsExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[TSDBStatsExposeParams]) (*mcp.CallToolResultFor[TSDBStatsExposeResult], error) {
+	result, err := e.API.TSDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[TSDBStatsExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}

--- a/pkg/statusexpose/wal_replay_stats.go
+++ b/pkg/statusexpose/wal_replay_stats.go
@@ -1,0 +1,30 @@
+package statusexpose
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type WALReplayStatsExposeParams struct{}
+
+type WALReplayStatsExposeResult = v1.WalReplayStatus
+
+func (e *statusExposer) WALReplayStatsExposeHandler(ctx context.Context, _ *mcp.ServerSession, _ *mcp.CallToolParamsFor[WALReplayStatsExposeParams]) (*mcp.CallToolResultFor[WALReplayStatsExposeResult], error) {
+	result, err := e.API.WalReplay(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.CallToolResultFor[WALReplayStatsExposeResult]{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(content)}},
+		StructuredContent: result,
+	}, nil
+}


### PR DESCRIPTION
The changes include:
- Added documentation in README.md for new status endpoints
- Implemented status exposure handlers in bindingblocks/tools.go
- Created new package statusexpose with handlers for:
 - Config
 - Flags
 - Runtime Information
 - Build Information
 - TSDB Stats
 - WAL Replay Stats

The purpose is to expose additional Prometheus server status information through new monitoring endpoints.