### PR TITLE
Centralize Go version definition in test coverage workflow

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - "main"
 
+env:
+  GO_VERSION: stable
+
 jobs:
   go-test-coverage:
     name: "Go Test Coverage"
@@ -14,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: ${{ env.GO_VERSION }}
       - run: go version
 
       - name: Generate test coverage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to use an environment variable for the Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->