### PR TITLE
ci(test-coverage): fetch artifacts from latest default branch run in PRs

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -30,16 +30,22 @@ jobs:
         run: |
           go test -race -count=1 -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
 
-      - name: Query default branch latest workflow run_id
+      - name: Query base default-branch latest run_id (this workflow)
         if: github.event_name == 'pull_request'
         id: query
+        env:
+          BASE_REPO: ${{ github.repository }}
+          BASE_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          echo "RUN_ID=$(curl -sSL \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          'https://api.github.com/repos/${{ github.repository }}/actions/runs?branch=${{ github.event.repository.default_branch }}&per_page=1' \
-          | jq -r '.workflow_runs[0].id')" >> "$GITHUB_OUTPUT"
+          id="$(curl -sSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${BASE_REPO}/actions/runs?branch=${BASE_DEFAULT_BRANCH}&event=push&status=completed&per_page=100" \
+            | jq -r '[.workflow_runs[] | select(.conclusion == "success" and .path == ".github/workflows/test-coverage.yml")] | first | .id // empty')"
+          if [ -n "$id" ]; then
+              echo "RUN_ID=$id" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download artifact (main.breakdown)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -55,6 +55,7 @@ jobs:
         continue-on-error: true
         with:
           name: main.breakdown
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.query.outputs.RUN_ID }}
 
       - name: Touch main.breakdown

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,9 +12,6 @@ on:
 env:
   GO_VERSION: stable
 
-permissions:
-  pull-requests: write
-
 jobs:
   go-test-coverage:
     name: "Go Test Coverage"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -46,6 +46,7 @@ jobs:
           if [ -n "$id" ]; then
               echo "RUN_ID=$id" >> "$GITHUB_OUTPUT"
           fi
+          echo "::notice::RUN_ID=$id"
 
       - name: Download artifact (main.breakdown)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -30,6 +30,17 @@ jobs:
         run: |
           go test -race -count=1 -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
 
+      - name: Query default branch latest workflow run_id
+        if: github.event_name == 'pull_request'
+        id: query
+        run: |
+          echo "RUN_ID=$(curl -sSL \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          'https://api.github.com/repos/${{ github.repository }}/actions/runs?branch=${{ github.event.repository.default_branch }}&per_page=1' \
+          | jq -r '.workflow_runs[0].id')" >> "$GITHUB_OUTPUT"
+
       - name: Download artifact (main.breakdown)
         if: github.event_name == 'pull_request'
         id: download-main-breakdown
@@ -37,6 +48,7 @@ jobs:
         continue-on-error: true
         with:
           name: main.breakdown
+          run-id: ${{ steps.query.outputs.RUN_ID }}
 
       - name: Touch main.breakdown
         if: github.event_name == 'pull_request' && steps.download-main-breakdown.outcome == 'failure'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,6 +12,9 @@ on:
 env:
   GO_VERSION: stable
 
+permissions:
+  pull-requests: write
+
 jobs:
   go-test-coverage:
     name: "Go Test Coverage"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -n "$id" ]; then
               echo "RUN_ID=$id" >> "$GITHUB_OUTPUT"
           fi
-          echo "::notice::RUN_ID=$id"
+          echo "::debug::RUN_ID=$id"
 
       - name: Download artifact (main.breakdown)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The changes focus on improving artifact handling during pull request workflows by:
1. Adding a step to query the latest workflow run ID from the default branch
2. Using this run ID to download the main.breakdown artifact
3. Maintaining compatibility through fallback handling when downloads fail

This ensures PR coverage comparisons always reference the most recent base branch metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test coverage workflow to ensure artifacts are downloaded from the latest successful run on the default branch during pull request events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->