### PR TITLE
ci: remove release footer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,9 +102,3 @@ release:
   # Default: true.
   # Templates: allowed. (Since v2.6)
   make_latest: false
-
-  footer: >-
-
-    ---
-
-    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release configuration updated to remove the footer from published release notes. The trailing “Released by” line will no longer appear on new releases. No changes to application behavior, installations, or upgrade processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->