### PR TITLE
fix(version): add fallback to gitrevision key for backward compatibility

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -105,6 +105,16 @@ func init() {
 					}
 				}
 			}
+
+			// If we didn't find vcs.revision, try the old key for backward compatibility
+			if len(GitCommit) == 0 {
+				for _, setting := range buildInfo.Settings {
+					if setting.Key == "gitrevision" {
+						GitCommit = setting.Value
+						break
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version reporting reliability across build environments. If the standard revision metadata is missing, the app now falls back to an older key to populate the Git commit.
  * Ensures commit information appears correctly in version outputs (e.g., CLI --version/About screens), preventing blank or incomplete data in some distributions and CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->