### PR TITLE
refactor: rename project name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
-    go build -o pmcp \
-    -ldflags="-s -w -X 'github.com/yshngg/pmcp/internal/version.Number=${VERSION_NUMBER}' -X 'github.com/yshngg/pmcp/internal/version.GitCommit=${GIT_COMMIT}' -X 'github.com/yshngg/pmcp/internal/version.BuildDate=${BUILD_DATE}'" \
+    go build -o prometheus-mcp-server \
+    -ldflags="-s -w -X 'github.com/yshngg/prometheus-mcp-server/internal/version.Number=${VERSION_NUMBER}' -X 'github.com/yshngg/prometheus-mcp-server/internal/version.GitCommit=${GIT_COMMIT}' -X 'github.com/yshngg/prometheus-mcp-server/internal/version.BuildDate=${BUILD_DATE}'" \
     .
 
 # Final image
@@ -28,8 +28,8 @@ FROM alpine:3.23
 
 WORKDIR /
 
-COPY --from=builder /app/pmcp /pmcp
+COPY --from=builder /app/prometheus-mcp-server /prometheus-mcp-server
 
 USER nobody
 
-ENTRYPOINT ["/pmcp"]
+ENTRYPOINT ["/prometheus-mcp-server"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD)
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # Package and binary name
-BINARY := pmcp
+BINARY := prometheus-mcp-server
 PACKAGE := $(shell go list -m)
 
 # Build flags

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# PMCP - Prometheus Model Context Protocol Server
+# Prometheus Model Context Protocol Server
 
-[![codecov](https://codecov.io/gh/yshngg/pmcp/graph/badge.svg?token=C64XY9GFP3)](https://codecov.io/gh/yshngg/pmcp)
-[![Go Report Card](https://goreportcard.com/badge/github.com/yshngg/pmcp)](https://goreportcard.com/report/github.com/yshngg/pmcp)
+[![codecov](https://codecov.io/gh/yshngg/prometheus-mcp-server/graph/badge.svg?token=C64XY9GFP3)](https://codecov.io/gh/yshngg/prometheus-mcp-server)
+[![Go Report Card](https://goreportcard.com/badge/github.com/yshngg/prometheus-mcp-server)](https://goreportcard.com/report/github.com/yshngg/prometheus-mcp-server)
 
 **🚀 A Golang-based Model Context Protocol (MCP) server implementation for Prometheus that enables natural language interactions with Prometheus metrics and queries.**
 
-**Built with Go**, PMCP provides a robust, type-safe interface that maintains full consistency with the Prometheus HTTP API, allowing you to query and manage your Prometheus instance through natural language conversations with MCP-compatible clients.
+**Built with Go**, `prometheus-mcp-server` provides a robust, type-safe interface that maintains full consistency with the Prometheus HTTP API, allowing you to query and manage your Prometheus instance through natural language conversations with MCP-compatible clients.
 
 ---
 
@@ -16,11 +16,11 @@
 3. [Requirements](#requirements)
 4. [Installation](#installation)
 5. [Usage](#usage)
-   * [Command Line Flags](#command-line-flags)
+   - [Command Line Flags](#command-line-flags)
 6. [API Compatibility](#api-compatibility)
 7. [Binding Blocks](#binding-blocks)
-   * [Tools](#tools)
-   * [Prompts](#prompts)
+   - [Tools](#tools)
+   - [Prompts](#prompts)
 8. [Contributing](#contributing)
 9. [License](#license)
 10. [Acknowledgments](#acknowledgments)
@@ -29,34 +29,34 @@
 
 ## Features
 
-* **🔥 Golang Implementation**: Built with Go 1.23+ for performance, reliability, and type safety
-* **📊 Complete Prometheus API Coverage**: Full compatibility with Prometheus HTTP API v1
-* **⚡ Instant Query**: Execute Prometheus queries at a specific point in time
-* **📈 Range Query**: Retrieve historical metric data over defined time ranges
-* **🔍 Metadata Query**: Discover time series, label names, and label values
-* **🎯 Target & Rule Management**: Monitor targets, rules, and alerting configurations
-* **🛠️ TSDB Administration**: Advanced database operations including snapshots and series deletion
-* **🌐 Multiple Transport Options**: Support for HTTP, Server-Sent Events (SSE), and stdio
-* **🤖 MCP Integration**: Seamless communication with MCP-compatible clients like Claude Desktop
+- **🔥 Golang Implementation**: Built with Go 1.23+ for performance, reliability, and type safety
+- **📊 Complete Prometheus API Coverage**: Full compatibility with Prometheus HTTP API v1
+- **⚡ Instant Query**: Execute Prometheus queries at a specific point in time
+- **📈 Range Query**: Retrieve historical metric data over defined time ranges
+- **🔍 Metadata Query**: Discover time series, label names, and label values
+- **🎯 Target & Rule Management**: Monitor targets, rules, and alerting configurations
+- **🛠️ TSDB Administration**: Advanced database operations including snapshots and series deletion
+- **🌐 Multiple Transport Options**: Support for HTTP, Server-Sent Events (SSE), and stdio
+- **🤖 MCP Integration**: Seamless communication with MCP-compatible clients like Claude Desktop
 
 ---
 
 ## Architecture
 
-PMCP is designed as a **Golang microservice** that acts as a bridge between MCP clients and Prometheus servers. It provides:
+`prometheus-mcp-server` is designed as a **Golang microservice** that acts as a bridge between MCP clients and Prometheus servers. It provides:
 
-* **Type-safe API bindings** using Go structs that mirror Prometheus API responses
-* **Modular package structure** for maintainability and extensibility  
-* **Comprehensive error handling** with proper Go error propagation
-* **Clean separation of concerns** between transport, API client, and business logic
+- **Type-safe API bindings** using Go structs that mirror Prometheus API responses
+- **Modular package structure** for maintainability and extensibility
+- **Comprehensive error handling** with proper Go error propagation
+- **Clean separation of concerns** between transport, API client, and business logic
 
 ---
 
 ## Requirements
 
-* **Go 1.23.0** or higher
-* A running **Prometheus server** (v2.x)
-* Compatible MCP client (Claude Desktop, custom implementations, etc.)
+- **Go 1.23.0** or higher
+- A running **Prometheus server** (v2.x)
+- Compatible MCP client (Claude Desktop, custom implementations, etc.)
 
 ---
 
@@ -68,55 +68,55 @@ Pull the pre-built image from GitHub Container Registry:
 
 ```bash
 # Pull the latest image
-docker pull ghcr.io/yshngg/pmcp:latest
+docker pull ghcr.io/yshngg/prometheus-mcp-server:latest
 
 # Run with stdio transport (for desktop clients)
-docker run --rm ghcr.io/yshngg/pmcp:latest --prom-addr="http://host.docker.internal:9090"
+docker run --rm ghcr.io/yshngg/prometheus-mcp-server:latest --prom-addr="http://host.docker.internal:9090"
 
 # Run with HTTP transport
-docker run --rm -p 8080:8080 ghcr.io/yshngg/pmcp:latest --prom-addr="http://host.docker.internal:9090" --transport=http --mcp-addr="0.0.0.0:8080"
+docker run --rm -p 8080:8080 ghcr.io/yshngg/prometheus-mcp-server:latest --prom-addr="http://host.docker.internal:9090" --transport=http --mcp-addr="0.0.0.0:8080"
 ```
 
 Alternatively, build locally:
 
 ```bash
-docker build -t pmcp .
-docker run -p 8080:8080 pmcp --prom-addr="http://prometheus:9090" --transport=http
+docker build -t prometheus-mcp-server .
+docker run -p 8080:8080 prometheus-mcp-server --prom-addr="http://prometheus:9090" --transport=http
 ```
 
 ### Download Pre-built Binary
 
 Download the latest release from GitHub:
 
-1. Go to [PMCP Releases](https://github.com/yshngg/pmcp/releases)
+1. Go to `prometheus-mcp-server` [Releases](https://github.com/yshngg/prometheus-mcp-server/releases)
 2. Download the appropriate binary for your platform from the **Assets** section
 3. Extract and run:
 
 ```bash
 # Linux/macOS example
-tar -xzf pmcp-<version>.linux-amd64.tar.gz
-./pmcp --prom-addr="http://localhost:9090"
+tar -xzf prometheus-mcp-server-<version>.linux-amd64.tar.gz
+./prometheus-mcp-server --prom-addr="http://localhost:9090"
 
 # Windows example
-unzip pmcp-<version>.windows-amd64.zip
-pmcp.exe --prom-addr="http://localhost:9090"
+unzip prometheus-mcp-server-<version>.windows-amd64.zip
+prometheus-mcp-server.exe --prom-addr="http://localhost:9090"
 ```
 
 ### Building from Source
 
 ```bash
-git clone https://github.com/yshngg/pmcp.git
-cd pmcp
+git clone https://github.com/yshngg/prometheus-mcp-server.git
+cd prometheus-mcp-server
 make build
-# Binary will be available as ./pmcp
+# Binary will be available as ./prometheus-mcp-server
 ```
 
 ### Using Go Install
 
-Install the `pmcp` binary directly from source:
+Install the `prometheus-mcp-server` binary directly from source:
 
 ```bash
-go install github.com/yshngg/pmcp@latest
+go install github.com/yshngg/prometheus-mcp-server@latest
 ```
 
 Ensure `$GOPATH/bin` is in your `$PATH`.
@@ -129,13 +129,13 @@ Run the server by specifying your Prometheus address and preferred transport:
 
 ```bash
 # Default (stdio transport) - ideal for desktop clients
-pmcp --prom-addr="http://localhost:9090"
+prometheus-mcp-server --prom-addr="http://localhost:9090"
 
 # HTTP transport - for web-based integrations
-pmcp --prom-addr="http://localhost:9090" --transport=http --mcp-addr="localhost:8080"
+prometheus-mcp-server --prom-addr="http://localhost:9090" --transport=http --mcp-addr="localhost:8080"
 
 # SSE transport - for real-time streaming (deprecated, use HTTP)
-pmcp --prom-addr="http://localhost:9090" --transport=sse --mcp-addr="localhost:8080"
+prometheus-mcp-server --prom-addr="http://localhost:9090" --transport=sse --mcp-addr="localhost:8080"
 ```
 
 ### Command Line Flags
@@ -152,61 +152,61 @@ pmcp --prom-addr="http://localhost:9090" --transport=sse --mcp-addr="localhost:8
 
 ## API Compatibility
 
-PMCP maintains **100% compatibility** with the Prometheus HTTP API v1. Every tool and endpoint corresponds directly to the official Prometheus API:
+`prometheus-mcp-server` maintains **100% compatibility** with the Prometheus HTTP API v1. Every tool and endpoint corresponds directly to the official Prometheus API:
 
 ### Query & Data Retrieval
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| Instant Query | `/api/v1/query` | GET/POST | Execute instant queries |
-| Range Query | `/api/v1/query_range` | GET/POST | Execute range queries |
+| Tool          | Prometheus Endpoint   | HTTP Method | Purpose                 |
+| ------------- | --------------------- | ----------- | ----------------------- |
+| Instant Query | `/api/v1/query`       | GET/POST    | Execute instant queries |
+| Range Query   | `/api/v1/query_range` | GET/POST    | Execute range queries   |
 
 ### Metadata & Discovery
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| Find Series by Labels | `/api/v1/series` | GET/POST | Find matching time series |
-| List Label Names | `/api/v1/labels` | GET/POST | List all label names |
-| List Label Values | `/api/v1/label/:name/values` | GET | List values for a specific label |
-| Target Discovery | `/api/v1/targets` | GET | Get target information |
-| Target Metadata Query | `/api/v1/targets/metadata` | GET | Get metadata from targets |
-| Metric Metadata Query | `/api/v1/metadata` | GET | Get metric metadata |
+| Tool                  | Prometheus Endpoint          | HTTP Method | Purpose                          |
+| --------------------- | ---------------------------- | ----------- | -------------------------------- |
+| Find Series by Labels | `/api/v1/series`             | GET/POST    | Find matching time series        |
+| List Label Names      | `/api/v1/labels`             | GET/POST    | List all label names             |
+| List Label Values     | `/api/v1/label/:name/values` | GET         | List values for a specific label |
+| Target Discovery      | `/api/v1/targets`            | GET         | Get target information           |
+| Target Metadata Query | `/api/v1/targets/metadata`   | GET         | Get metadata from targets        |
+| Metric Metadata Query | `/api/v1/metadata`           | GET         | Get metric metadata              |
 
 ### Rules & Alerts
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| Alert Query | `/api/v1/alerts` | GET | Get all active alerts |
-| Rule Query | `/api/v1/rules` | GET | Get recording/alerting rules |
-| Alertmanager Discovery | `/api/v1/alertmanagers` | GET | Get alertmanager information |
+| Tool                   | Prometheus Endpoint     | HTTP Method | Purpose                      |
+| ---------------------- | ----------------------- | ----------- | ---------------------------- |
+| Alert Query            | `/api/v1/alerts`        | GET         | Get all active alerts        |
+| Rule Query             | `/api/v1/rules`         | GET         | Get recording/alerting rules |
+| Alertmanager Discovery | `/api/v1/alertmanagers` | GET         | Get alertmanager information |
 
 ### Status & Configuration
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| Config | `/api/v1/status/config` | GET | Get current configuration |
-| Flags | `/api/v1/status/flags` | GET | Get runtime flags |
-| Build Information | `/api/v1/status/buildinfo` | GET | Get build information |
-| Runtime Information | `/api/v1/status/runtimeinfo` | GET | Get runtime information |
-| TSDB Stats | `/api/v1/status/tsdb` | GET | Get TSDB statistics |
-| WAL Replay Stats | `/api/v1/status/walreplay` | GET | Get WAL replay status |
+| Tool                | Prometheus Endpoint          | HTTP Method | Purpose                   |
+| ------------------- | ---------------------------- | ----------- | ------------------------- |
+| Config              | `/api/v1/status/config`      | GET         | Get current configuration |
+| Flags               | `/api/v1/status/flags`       | GET         | Get runtime flags         |
+| Build Information   | `/api/v1/status/buildinfo`   | GET         | Get build information     |
+| Runtime Information | `/api/v1/status/runtimeinfo` | GET         | Get runtime information   |
+| TSDB Stats          | `/api/v1/status/tsdb`        | GET         | Get TSDB statistics       |
+| WAL Replay Stats    | `/api/v1/status/walreplay`   | GET         | Get WAL replay status     |
 
 ### TSDB Administration
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| TSDB Snapshot | `/api/v1/admin/tsdb/snapshot` | POST/PUT | Create TSDB snapshot |
-| Delete Series | `/api/v1/admin/tsdb/delete_series` | POST/PUT | Delete time series data |
-| Clean Tombstones | `/api/v1/admin/tsdb/clean_tombstones` | POST/PUT | Clean deleted data |
+| Tool             | Prometheus Endpoint                   | HTTP Method | Purpose                 |
+| ---------------- | ------------------------------------- | ----------- | ----------------------- |
+| TSDB Snapshot    | `/api/v1/admin/tsdb/snapshot`         | POST/PUT    | Create TSDB snapshot    |
+| Delete Series    | `/api/v1/admin/tsdb/delete_series`    | POST/PUT    | Delete time series data |
+| Clean Tombstones | `/api/v1/admin/tsdb/clean_tombstones` | POST/PUT    | Clean deleted data      |
 
 ### Management APIs
 
-| PMCP Tool | Prometheus Endpoint | HTTP Method | Purpose |
-|-----------|-------------------|-------------|---------|
-| Health Check | `/-/healthy` | GET/HEAD | Check Prometheus health |
-| Readiness Check | `/-/ready` | GET/HEAD | Check if ready to serve |
-| Reload | `/-/reload` | PUT/POST | Reload configuration |
-| Quit | `/-/quit` | PUT/POST | Graceful shutdown |
+| Tool            | Prometheus Endpoint | HTTP Method | Purpose                 |
+| --------------- | ------------------- | ----------- | ----------------------- |
+| Health Check    | `/-/healthy`        | GET/HEAD    | Check Prometheus health |
+| Readiness Check | `/-/ready`          | GET/HEAD    | Check if ready to serve |
+| Reload          | `/-/reload`         | PUT/POST    | Reload configuration    |
+| Quit            | `/-/quit`           | PUT/POST    | Graceful shutdown       |
 
 **All query parameters, response formats, and error codes match the official Prometheus API specification.**
 
@@ -218,49 +218,49 @@ PMCP maintains **100% compatibility** with the Prometheus HTTP API v1. Every too
 
 **Expression Queries** (Core Prometheus functionality):
 
-* **Instant Query**: Evaluate an instant query at a single point in time
-* **Range Query**: Evaluate an expression query over a range of time
+- **Instant Query**: Evaluate an instant query at a single point in time
+- **Range Query**: Evaluate an expression query over a range of time
 
 **Metadata Queries** (Series and label discovery):
 
-* **Find Series by Labels**: Return the list of time series that match a certain label set
-* **List Label Names**: Return a list of label names
-* **List Label Values**: Return a list of label values for a provided label name
-* **Target Metadata Query**: Return metadata about metrics currently scraped from targets
-* **Metric Metadata Query**: Return metadata about metrics currently scraped from targets (without target information)
+- **Find Series by Labels**: Return the list of time series that match a certain label set
+- **List Label Names**: Return a list of label names
+- **List Label Values**: Return a list of label values for a provided label name
+- **Target Metadata Query**: Return metadata about metrics currently scraped from targets
+- **Metric Metadata Query**: Return metadata about metrics currently scraped from targets (without target information)
 
 **Discovery & Monitoring**:
 
-* **Target Discovery**: Return an overview of the current state of the Prometheus target discovery
-* **Alert Query**: Return a list of all active alerts
-* **Rule Query**: Return a list of alerting and recording rules that are currently loaded
-* **Alertmanager Discovery**: Return an overview of the current state of the Prometheus alertmanager discovery
+- **Target Discovery**: Return an overview of the current state of the Prometheus target discovery
+- **Alert Query**: Return a list of all active alerts
+- **Rule Query**: Return a list of alerting and recording rules that are currently loaded
+- **Alertmanager Discovery**: Return an overview of the current state of the Prometheus alertmanager discovery
 
 **Status & Configuration**:
 
-* **Config**: Return currently loaded configuration file
-* **Flags**: Return flag values that Prometheus was configured with
-* **Runtime Information**: Return various runtime information properties about the Prometheus server
-* **Build Information**: Return various build information properties about the Prometheus server
-* **TSDB Stats**: Return various cardinality statistics about the Prometheus TSDB
-* **WAL Replay Stats**: Return information about the WAL replay
+- **Config**: Return currently loaded configuration file
+- **Flags**: Return flag values that Prometheus was configured with
+- **Runtime Information**: Return various runtime information properties about the Prometheus server
+- **Build Information**: Return various build information properties about the Prometheus server
+- **TSDB Stats**: Return various cardinality statistics about the Prometheus TSDB
+- **WAL Replay Stats**: Return information about the WAL replay
 
 **TSDB Admin APIs** (Advanced operations):
 
-* **TSDB Snapshot**: Create a snapshot of all current data into snapshots/`<datetime>`-`<rand>`
-* **Delete Series**: Delete data for a selection of series in a time range
-* **Clean Tombstones**: Remove the deleted data from disk and cleans up the existing tombstones
+- **TSDB Snapshot**: Create a snapshot of all current data into snapshots/`<datetime>`-`<rand>`
+- **Delete Series**: Delete data for a selection of series in a time range
+- **Clean Tombstones**: Remove the deleted data from disk and cleans up the existing tombstones
 
 **Management APIs**:
 
-* **Health Check**: Check Prometheus health
-* **Readiness Check**: Check if Prometheus is ready to serve traffic (i.e. respond to queries)
-* **Reload**: Trigger a reload of the Prometheus configuration and rule files
-* **Quit**: Trigger a graceful shutdown of Prometheus
+- **Health Check**: Check Prometheus health
+- **Readiness Check**: Check if Prometheus is ready to serve traffic (i.e. respond to queries)
+- **Reload**: Trigger a reload of the Prometheus configuration and rule files
+- **Quit**: Trigger a graceful shutdown of Prometheus
 
 ### Prompts
 
-* **All Available Metrics**: Return a list of every metric exposed by the Prometheus instance
+- **All Available Metrics**: Return a list of every metric exposed by the Prometheus instance
 
 ---
 
@@ -268,18 +268,18 @@ PMCP maintains **100% compatibility** with the Prometheus HTTP API v1. Every too
 
 Contributions are welcome! This is a **Golang project**, so please ensure:
 
-* Follow Go best practices and conventions
-* Add appropriate tests for new functionality
-* Maintain API compatibility with Prometheus
-* Update documentation as needed
+- Follow Go best practices and conventions
+- Add appropriate tests for new functionality
+- Maintain API compatibility with Prometheus
+- Update documentation as needed
 
 Please submit a pull request or open an issue to discuss improvements.
 
 ### Development Setup
 
 ```bash
-git clone https://github.com/yshngg/pmcp.git
-cd pmcp
+git clone https://github.com/yshngg/prometheus-mcp-server.git
+cd prometheus-mcp-server
 go mod download
 make build
 ```
@@ -294,6 +294,6 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE
 
 ## Acknowledgments
 
-* **Built with Go** using the official [Prometheus Go client library](https://github.com/prometheus/client_golang)
-* Powered by [Model Context Protocol Go SDK](https://github.com/modelcontextprotocol/go-sdk)
-* Inspired by [Prometheus](https://prometheus.io/) - the de facto standard for monitoring and alerting
+- **Built with Go** using the official [Prometheus Go client library](https://github.com/prometheus/client_golang)
+- Powered by [Model Context Protocol Go SDK](https://github.com/modelcontextprotocol/go-sdk)
+- Inspired by [Prometheus](https://prometheus.io/) - the de facto standard for monitoring and alerting

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yshngg/pmcp
+module github.com/yshngg/prometheus-mcp-server
 
 go 1.24.0
 

--- a/internal/alertmanagerdiscover/discover.go
+++ b/internal/alertmanagerdiscover/discover.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type AlertmanagerDiscoverer interface {

--- a/internal/alertquery/query.go
+++ b/internal/alertquery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type AlertQuerier interface {

--- a/internal/bindingblocks/binder.go
+++ b/internal/bindingblocks/binder.go
@@ -2,7 +2,7 @@ package bindingblocks
 
 import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type Binder interface {

--- a/internal/bindingblocks/tools.go
+++ b/internal/bindingblocks/tools.go
@@ -2,15 +2,15 @@ package bindingblocks
 
 import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/alertmanagerdiscover"
-	"github.com/yshngg/pmcp/internal/alertquery"
-	"github.com/yshngg/pmcp/internal/expressionquery"
-	"github.com/yshngg/pmcp/internal/manage"
-	"github.com/yshngg/pmcp/internal/metadataquery"
-	"github.com/yshngg/pmcp/internal/rulequery"
-	"github.com/yshngg/pmcp/internal/statusexpose"
-	"github.com/yshngg/pmcp/internal/targetdiscover"
-	"github.com/yshngg/pmcp/internal/tsdbadmin"
+	"github.com/yshngg/prometheus-mcp-server/internal/alertmanagerdiscover"
+	"github.com/yshngg/prometheus-mcp-server/internal/alertquery"
+	"github.com/yshngg/prometheus-mcp-server/internal/expressionquery"
+	"github.com/yshngg/prometheus-mcp-server/internal/manage"
+	"github.com/yshngg/prometheus-mcp-server/internal/metadataquery"
+	"github.com/yshngg/prometheus-mcp-server/internal/rulequery"
+	"github.com/yshngg/prometheus-mcp-server/internal/statusexpose"
+	"github.com/yshngg/prometheus-mcp-server/internal/targetdiscover"
+	"github.com/yshngg/prometheus-mcp-server/internal/tsdbadmin"
 )
 
 // addTools registers Prometheus query tools with the MCP server.

--- a/internal/expressionquery/instant_query.go
+++ b/internal/expressionquery/instant_query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 const InstantQueryEndpoint = "/query"

--- a/internal/expressionquery/query.go
+++ b/internal/expressionquery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type ExpressionQuerier interface {

--- a/internal/expressionquery/range_query.go
+++ b/internal/expressionquery/range_query.go
@@ -9,7 +9,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 const RangeQueryEndpoint = "/query_range"

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type ManagementResult struct {

--- a/internal/metadataquery/labels.go
+++ b/internal/metadataquery/labels.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 const LabelNamesEndpoint = "/labels"

--- a/internal/metadataquery/query.go
+++ b/internal/metadataquery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type MetadataQuerier interface {

--- a/internal/metadataquery/series.go
+++ b/internal/metadataquery/series.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 const SeriesEndpoint = "/series"

--- a/internal/metadataquery/values.go
+++ b/internal/metadataquery/values.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 const LabelValuesEndpoint = "/label/<label_name>/values"

--- a/internal/rulequery/query.go
+++ b/internal/rulequery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type RuleQuerier interface {

--- a/internal/statusexpose/expose.go
+++ b/internal/statusexpose/expose.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type StatusExposer interface {

--- a/internal/targetdiscover/discover.go
+++ b/internal/targetdiscover/discover.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 const TargetDiscoverEndpoint = "/targets"

--- a/internal/tsdbadmin/admin.go
+++ b/internal/tsdbadmin/admin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
 type TSDBAdmin interface {

--- a/internal/tsdbadmin/delete_series.go
+++ b/internal/tsdbadmin/delete_series.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
 // URL query parameters:

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/pmcp/internal/bindingblocks"
-	"github.com/yshngg/pmcp/internal/prometheus/api"
-	"github.com/yshngg/pmcp/internal/version"
+	"github.com/yshngg/prometheus-mcp-server/internal/bindingblocks"
+	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/version"
 )
 
 // Schema is the identifier for the Prometheus schema.
@@ -25,7 +25,7 @@ const Schema = "prom"
 // and serves requests until termination.
 // The function exits the program on critical errors or when printing version information.
 func main() {
-	fs := flag.NewFlagSet("pmcp", flag.ExitOnError)
+	fs := flag.NewFlagSet("prometheus-mcp-server", flag.ExitOnError)
 	var (
 		// promAddr is the address of the Prometheus server to connect to.
 		promAddr = fs.String("prom-addr", "http://localhost:9090/", "The address of the Prometheus to connect to.")
@@ -36,7 +36,7 @@ func main() {
 		// printVersion prints the version and exit.
 		printVersion = fs.Bool("version", false, "Print the version and exit.")
 	)
-	fs.Usage = usageFor(fs, "pmcp [flags]")
+	fs.Usage = usageFor(fs, "prometheus-mcp-server [flags]")
 	// Parse command-line flags.
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		slog.Error("parse args", "err", err)
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "pmcp",
+		Name:    "prometheus-mcp-server",
 		Version: string(version.Info.Number),
 	}, nil)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed project from pmcp to prometheus-mcp-server across binary, module path, and internal references.
  * Updated build configuration and Docker image references to reflect new project name.

* **Documentation**
  * Updated README with new project branding, repository links, and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->