### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yshngg-pmcp).
+
 ## Features
 
 - **🔥 Golang Implementation**: Built with Go 1.23+ for performance, reliability, and type safety


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yshngg-pmcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Hosted deployment" section to the README introducing an externally hosted deployment option on Frontier AI with a direct link to access it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->