### PR TITLE
fix: modify tool names to comply with MCP SEP-986

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@
 
 - **🔥 Golang Implementation**: Built with Go 1.23+ for performance, reliability, and type safety
 - **📊 Complete Prometheus API Coverage**: Full compatibility with Prometheus HTTP API v1
-- **⚡ Instant Query**: Execute Prometheus queries at a specific point in time
-- **📈 Range Query**: Retrieve historical metric data over defined time ranges
-- **🔍 Metadata Query**: Discover time series, label names, and label values
+- **⚡ instant-query**: Execute Prometheus queries at a specific point in time
+- **📈 range-query**: Retrieve historical metric data over defined time ranges
+- **🔍 Metadata Queries**: Discover time series, label names, and label values
 - **🎯 Target & Rule Management**: Monitor targets, rules, and alerting configurations
 - **🛠️ TSDB Administration**: Advanced database operations including snapshots and series deletion
 - **🌐 Multiple Transport Options**: Support for HTTP, Server-Sent Events (SSE), and stdio
@@ -159,55 +159,55 @@ prometheus-mcp-server --prom-addr="http://localhost:9090" --transport=sse --mcp-
 
 | Tool          | Prometheus Endpoint   | HTTP Method | Purpose                 |
 | ------------- | --------------------- | ----------- | ----------------------- |
-| Instant Query | `/api/v1/query`       | GET/POST    | Execute instant queries |
-| Range Query   | `/api/v1/query_range` | GET/POST    | Execute range queries   |
+| instant-query | `/api/v1/query`       | GET/POST    | Execute instant queries |
+| range-query   | `/api/v1/query_range` | GET/POST    | Execute range queries   |
 
 ### Metadata & Discovery
 
 | Tool                  | Prometheus Endpoint          | HTTP Method | Purpose                          |
 | --------------------- | ---------------------------- | ----------- | -------------------------------- |
-| Find Series by Labels | `/api/v1/series`             | GET/POST    | Find matching time series        |
-| List Label Names      | `/api/v1/labels`             | GET/POST    | List all label names             |
-| List Label Values     | `/api/v1/label/:name/values` | GET         | List values for a specific label |
-| Target Discovery      | `/api/v1/targets`            | GET         | Get target information           |
-| Target Metadata Query | `/api/v1/targets/metadata`   | GET         | Get metadata from targets        |
-| Metric Metadata Query | `/api/v1/metadata`           | GET         | Get metric metadata              |
+| find-series-by-labels | `/api/v1/series`             | GET/POST    | Find matching time series        |
+| list-label-names      | `/api/v1/labels`             | GET/POST    | List all label names             |
+| list-label-values     | `/api/v1/label/:name/values` | GET         | List values for a specific label |
+| target-discovery      | `/api/v1/targets`            | GET         | Get target information           |
+| target-metadata-query | `/api/v1/targets/metadata`   | GET         | Get metadata from targets        |
+| metric-metadata-query | `/api/v1/metadata`           | GET         | Get metric metadata              |
 
 ### Rules & Alerts
 
 | Tool                   | Prometheus Endpoint     | HTTP Method | Purpose                      |
 | ---------------------- | ----------------------- | ----------- | ---------------------------- |
-| Alert Query            | `/api/v1/alerts`        | GET         | Get all active alerts        |
-| Rule Query             | `/api/v1/rules`         | GET         | Get recording/alerting rules |
-| Alertmanager Discovery | `/api/v1/alertmanagers` | GET         | Get alertmanager information |
+| alert-query            | `/api/v1/alerts`        | GET         | Get all active alerts        |
+| rule-query             | `/api/v1/rules`         | GET         | Get recording/alerting rules |
+| alertmanager-discovery | `/api/v1/alertmanagers` | GET         | Get alertmanager information |
 
 ### Status & Configuration
 
 | Tool                | Prometheus Endpoint          | HTTP Method | Purpose                   |
 | ------------------- | ---------------------------- | ----------- | ------------------------- |
-| Config              | `/api/v1/status/config`      | GET         | Get current configuration |
-| Flags               | `/api/v1/status/flags`       | GET         | Get runtime flags         |
-| Build Information   | `/api/v1/status/buildinfo`   | GET         | Get build information     |
-| Runtime Information | `/api/v1/status/runtimeinfo` | GET         | Get runtime information   |
-| TSDB Stats          | `/api/v1/status/tsdb`        | GET         | Get TSDB statistics       |
-| WAL Replay Stats    | `/api/v1/status/walreplay`   | GET         | Get WAL replay status     |
+| config              | `/api/v1/status/config`      | GET         | Get current configuration |
+| flags               | `/api/v1/status/flags`       | GET         | Get runtime flags         |
+| build-information   | `/api/v1/status/buildinfo`   | GET         | Get build information     |
+| runtime-information | `/api/v1/status/runtimeinfo` | GET         | Get runtime information   |
+| tsdb-stats          | `/api/v1/status/tsdb`        | GET         | Get TSDB statistics       |
+| wal-replay-stats    | `/api/v1/status/walreplay`   | GET         | Get WAL replay status     |
 
 ### TSDB Administration
 
 | Tool             | Prometheus Endpoint                   | HTTP Method | Purpose                 |
 | ---------------- | ------------------------------------- | ----------- | ----------------------- |
-| TSDB Snapshot    | `/api/v1/admin/tsdb/snapshot`         | POST/PUT    | Create TSDB snapshot    |
-| Delete Series    | `/api/v1/admin/tsdb/delete_series`    | POST/PUT    | Delete time series data |
-| Clean Tombstones | `/api/v1/admin/tsdb/clean_tombstones` | POST/PUT    | Clean deleted data      |
+| tsdb-snapshot    | `/api/v1/admin/tsdb/snapshot`         | POST/PUT    | Create TSDB snapshot    |
+| delete-series    | `/api/v1/admin/tsdb/delete_series`    | POST/PUT    | Delete time series data |
+| clean-tombstones | `/api/v1/admin/tsdb/clean_tombstones` | POST/PUT    | Clean deleted data      |
 
 ### Management APIs
 
 | Tool            | Prometheus Endpoint | HTTP Method | Purpose                 |
 | --------------- | ------------------- | ----------- | ----------------------- |
-| Health Check    | `/-/healthy`        | GET/HEAD    | Check Prometheus health |
-| Readiness Check | `/-/ready`          | GET/HEAD    | Check if ready to serve |
-| Reload          | `/-/reload`         | PUT/POST    | Reload configuration    |
-| Quit            | `/-/quit`           | PUT/POST    | Graceful shutdown       |
+| health-check    | `/-/healthy`        | GET/HEAD    | Check Prometheus health |
+| readiness-check | `/-/ready`          | GET/HEAD    | Check if ready to serve |
+| reload          | `/-/reload`         | PUT/POST    | Reload configuration    |
+| quit            | `/-/quit`           | PUT/POST    | Graceful shutdown       |
 
 **All query parameters, response formats, and error codes match the official Prometheus API specification.**
 
@@ -219,49 +219,49 @@ prometheus-mcp-server --prom-addr="http://localhost:9090" --transport=sse --mcp-
 
 **Expression Queries** (Core Prometheus functionality):
 
-- **Instant Query**: Evaluate an instant query at a single point in time
-- **Range Query**: Evaluate an expression query over a range of time
+- **instant-query**: Evaluate an instant query at a single point in time
+- **range-query**: Evaluate an expression query over a range of time
 
 **Metadata Queries** (Series and label discovery):
 
-- **Find Series by Labels**: Return the list of time series that match a certain label set
-- **List Label Names**: Return a list of label names
-- **List Label Values**: Return a list of label values for a provided label name
-- **Target Metadata Query**: Return metadata about metrics currently scraped from targets
-- **Metric Metadata Query**: Return metadata about metrics currently scraped from targets (without target information)
+- **find-series-by-labels**: Return the list of time series that match a certain label set
+- **list-label-names**: Return a list of label names
+- **list-label-values**: Return a list of label values for a provided label name
+- **target-metadata-query**: Return metadata about metrics currently scraped from targets
+- **metric-metadata-query**: Return metadata about metrics currently scraped from targets (without target information)
 
 **Discovery & Monitoring**:
 
-- **Target Discovery**: Return an overview of the current state of the Prometheus target discovery
-- **Alert Query**: Return a list of all active alerts
-- **Rule Query**: Return a list of alerting and recording rules that are currently loaded
-- **Alertmanager Discovery**: Return an overview of the current state of the Prometheus alertmanager discovery
+- **target-discovery**: Return an overview of the current state of the Prometheus target discovery
+- **alert-query**: Return a list of all active alerts
+- **rule-query**: Return a list of alerting and recording rules that are currently loaded
+- **alertmanager-discovery**: Return an overview of the current state of the Prometheus alertmanager discovery
 
 **Status & Configuration**:
 
-- **Config**: Return currently loaded configuration file
-- **Flags**: Return flag values that Prometheus was configured with
-- **Runtime Information**: Return various runtime information properties about the Prometheus server
-- **Build Information**: Return various build information properties about the Prometheus server
-- **TSDB Stats**: Return various cardinality statistics about the Prometheus TSDB
-- **WAL Replay Stats**: Return information about the WAL replay
+- **config**: Return currently loaded configuration file
+- **flags**: Return flag values that Prometheus was configured with
+- **runtime-information**: Return various runtime information properties about the Prometheus server
+- **build-information**: Return various build information properties about the Prometheus server
+- **tsdb-stats**: Return various cardinality statistics about the Prometheus TSDB
+- **wal-replay-stats**: Return information about the WAL replay
 
 **TSDB Admin APIs** (Advanced operations):
 
-- **TSDB Snapshot**: Create a snapshot of all current data into snapshots/`<datetime>`-`<rand>`
-- **Delete Series**: Delete data for a selection of series in a time range
-- **Clean Tombstones**: Remove the deleted data from disk and cleans up the existing tombstones
+- **tsdb-snapshot**: Create a snapshot of all current data into snapshots/`<datetime>`-`<rand>`
+- **delete-series**: Delete data for a selection of series in a time range
+- **clean-tombstones**: Remove the deleted data from disk and cleans up the existing tombstones
 
 **Management APIs**:
 
-- **Health Check**: Check Prometheus health
-- **Readiness Check**: Check if Prometheus is ready to serve traffic (i.e. respond to queries)
-- **Reload**: Trigger a reload of the Prometheus configuration and rule files
-- **Quit**: Trigger a graceful shutdown of Prometheus
+- **health-check**: Check Prometheus health
+- **readiness-check**: Check if Prometheus is ready to serve traffic (i.e. respond to queries)
+- **reload**: Trigger a reload of the Prometheus configuration and rule files
+- **quit**: Trigger a graceful shutdown of Prometheus
 
 ### Prompts
 
-- **All Available Metrics**: Return a list of every metric exposed by the Prometheus instance
+- **all-available-metrics**: Return a list of every metric exposed by the Prometheus instance
 
 ---
 

--- a/internal/bindingblocks/prompts.go
+++ b/internal/bindingblocks/prompts.go
@@ -8,7 +8,7 @@ import (
 
 func (b *binder) addPrompts() {
 	b.server.AddPrompt(&mcp.Prompt{
-		Name:        "All Available Metrics",
+		Name:        "all-available-metrics",
 		Description: "List all available metrics in the Prometheus instance.",
 	}, func(ctx context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		return &mcp.GetPromptResult{

--- a/internal/bindingblocks/tools.go
+++ b/internal/bindingblocks/tools.go
@@ -21,12 +21,12 @@ func (b *binder) addTools() {
 	{
 		expressionQuerier := expressionquery.NewExpressionQuerier(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Instant Query",
+			Name:        "instant-query",
 			Description: "Evaluate an instant query at a single point in time.",
 		}, expressionQuerier.InstantQueryHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Range Query",
+			Name:        "range-query",
 			Description: "Evaluate an expression query over a range of time.",
 		}, expressionQuerier.RangeQueryHandler)
 	}
@@ -36,27 +36,27 @@ func (b *binder) addTools() {
 	{
 		metadataQuerier := metadataquery.NewMetadataQuerier(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Find Series by Labels",
+			Name:        "find-series-by-labels",
 			Description: "Return the list of time series that match a certain label set.",
 		}, metadataQuerier.SeriesHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "List Label Names",
+			Name:        "list-label-names",
 			Description: "Return a list of label names.",
 		}, metadataQuerier.LabelNamesHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "List Label Values",
+			Name:        "list-label-values",
 			Description: "Return a list of label values for a provided label name.",
 		}, metadataQuerier.LabelValuesHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Target Metadata Query",
+			Name:        "target-metadata-query",
 			Description: "Return metadata about metrics currently scraped from targets.",
 		}, metadataQuerier.TargetMetadataQueryHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Metric Metadata Query",
+			Name:        "metric-metadata-query",
 			Description: "Return metadata about metrics currently scraped from targets. However, it does not provide any target information.",
 		}, metadataQuerier.MetricsMetadataQueryHandler)
 	}
@@ -66,7 +66,7 @@ func (b *binder) addTools() {
 	{
 		targetDiscoverer := targetdiscover.NewTargetDiscoverer(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Target Discovery",
+			Name:        "target-discovery",
 			Description: "Return an overview of the current state of the Prometheus target discovery.",
 		}, targetDiscoverer.TargetDiscoverHandler)
 	}
@@ -76,7 +76,7 @@ func (b *binder) addTools() {
 	{
 		ruleQuerier := rulequery.NewRuleQuerier(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Rule Query",
+			Name:        "rule-query",
 			Description: "Return a list of alerting and recording rules that are currently loaded. In addition it returns the currently active alerts fired by the Prometheus instance of each alerting rule.",
 		}, ruleQuerier.RuleQueryHandler)
 	}
@@ -86,7 +86,7 @@ func (b *binder) addTools() {
 	{
 		alertQuerier := alertquery.NewAlertQuerier(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Alert Query",
+			Name:        "alert-query",
 			Description: "Return a list of all active alerts.",
 		}, alertQuerier.AlertQueryHandler)
 	}
@@ -96,7 +96,7 @@ func (b *binder) addTools() {
 	{
 		alertmanagerDiscoverer := alertmanagerdiscover.NewAlertmanagerDiscoverer(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Alertmanager Discovery",
+			Name:        "alertmanager-discovery",
 			Description: "Return an overview of the current state of the Prometheus alertmanager discovery.",
 		}, alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
 	}
@@ -116,22 +116,22 @@ func (b *binder) addTools() {
 		}, statusExposer.FlagsExposeHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Runtime Information",
+			Name:        "runtime-information",
 			Description: "Return various runtime information properties about the Prometheus server.",
 		}, statusExposer.RuntimeInformationExposeHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Build Information",
+			Name:        "build-information",
 			Description: "Return various build information properties about the Prometheus server.",
 		}, statusExposer.BuildInformationExposeHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "TSDB Stats",
+			Name:        "tsdb-stats",
 			Description: "Return various cardinality statistics about the Prometheus TSDB.",
 		}, statusExposer.TSDBStatsExposeHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "WAL Replay Stats",
+			Name:        "wal-replay-stats",
 			Description: "Return information about the WAL replay.",
 		}, statusExposer.WALReplayStatsExposeHandler)
 	}
@@ -141,17 +141,17 @@ func (b *binder) addTools() {
 	{
 		tsdbAdmin := tsdbadmin.NewTSDBAdmin(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "TSDB Snapshot",
+			Name:        "tsdb-snapshot",
 			Description: "Create a snapshot of all current data into snapshots/<datetime>-<rand> under the TSDB's data directory and returns the directory as response. It will optionally skip snapshotting data that is only present in the head block, and which has not yet been compacted to disk.",
 		}, tsdbAdmin.SnapshotHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Delete Series",
+			Name:        "delete-series",
 			Description: "Delete data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the Clean Tombstones endpoint. Not mentioning both start and end times would clear all the data for the matched series in the database.",
 		}, tsdbAdmin.DeleteSeriesHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Clean Tombstones",
+			Name:        "clean-tombstones",
 			Description: "Remove the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space.",
 		}, tsdbAdmin.CleanTombstonesHandler)
 	}
@@ -161,12 +161,12 @@ func (b *binder) addTools() {
 	{
 		manager := manage.NewManager(b.api)
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Health Check",
+			Name:        "health-check",
 			Description: "Check Prometheus health.",
 		}, manager.HealthCheckHandler)
 
 		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "Readiness Check",
+			Name:        "readiness-check",
 			Description: "Check if Prometheus is ready to serve traffic (i.e. respond to queries).",
 		}, manager.ReadinessCheckHandler)
 


### PR DESCRIPTION
## Summary

Rename all tool names and prompt names from Title Case with spaces to kebab-case to comply with [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986), which restricts tool names to `[A-Za-z0-9_-./]` with no spaces.

## Changes

- **`internal/bindingblocks/tools.go`**: 24 tool names renamed to kebab-case (e.g. `"Instant Query"` → `"instant-query"`)
- **`internal/bindingblocks/prompts.go`**: 1 prompt name renamed (`"All Available Metrics"` → `"all-available-metrics"`)
- **`README.md`**: Updated all tool name references in tables, bullet lists, and feature descriptions

## Breaking Change

Tool consumers must use the new kebab-case names. No alias/deprecation shim is provided.

## Verification

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — passes

Closes #99