### PR TITLE
ci: update golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: stable
-  GOLANGCI_LINT_VERSION: v2.1
+  GOLANGCI_LINT_VERSION: v2.12.2
 
 jobs:
   detect-modules:


### PR DESCRIPTION
Bump golangci-lint from v2.1 to v2.12.2 to fix CI failure:

```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

The pinned v2.1 was compiled with Go 1.24, but `go.mod` specifies `go 1.25.0`. v2.12.2 is compiled with a compatible Go version.