### PR TITLE
ci: fix goreleaser Go version by reading from go.mod

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,6 +22,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
The `actions/setup-go@v6` step in `goreleaser.yml` was missing `go-version` or `go-version-file`, so it defaulted to Go 1.24 on the runner, causing:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

Fixed by adding `go-version-file: go.mod` so it reads the required version from `go.mod` (go 1.25.0).