### PR TITLE
ci: align Go version with go.mod across all workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,7 +7,6 @@ on:
       - main
 
 env:
-  GO_VERSION: stable
   GOLANGCI_LINT_VERSION: v2.12.2
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - id: set-modules
         run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> $GITHUB_OUTPUT
 
@@ -35,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: golangci-lint ${{ matrix.modules }}
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - "main"
 
-env:
-  GO_VERSION: stable
-
 permissions:
   pull-requests: write
 
@@ -23,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: go version
 
       - name: Generate test coverage


### PR DESCRIPTION
Replace `GO_VERSION: stable` with `go-version-file: go.mod` in `golangci-lint.yml` and `test-coverage.yml` so CI uses exactly the Go version specified in `go.mod` (`go 1.25.0`).

`vulncheck.yml` is left unchanged (`GO_VERSION: stable`) per maintainer preference.

**Files changed:**
- `.github/workflows/golangci-lint.yml` — removed `GO_VERSION` env, both `setup-go` steps now use `go-version-file: go.mod`
- `.github/workflows/test-coverage.yml` — removed `GO_VERSION` env, `setup-go` now uses `go-version-file: go.mod`