### PR TITLE
perf: optimize MCP server performance and add comprehensive tests

### DIFF
--- a/internal/alertmanagerdiscover/alertmanagerdiscover_test.go
+++ b/internal/alertmanagerdiscover/alertmanagerdiscover_test.go
@@ -1,0 +1,39 @@
+package alertmanagerdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func TestAlertmanagerDiscoverHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		AlertManagersFunc: func(ctx context.Context) (v1.AlertManagersResult, error) {
+			return v1.AlertManagersResult{Active: []v1.AlertManager{{URL: "http://alertmanager:9093"}}}, nil
+		},
+	}
+	d := NewAlertmanagerDiscoverer(mock)
+	_, result, err := d.AlertmanagerDiscoverHandler(context.Background(), nil, &AlertmanagerDiscoverParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Active) != 1 {
+		t.Fatalf("expected 1 active alertmanager, got %d", len(result.Active))
+	}
+}
+
+func TestAlertmanagerDiscoverHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		AlertManagersFunc: func(ctx context.Context) (v1.AlertManagersResult, error) {
+			return v1.AlertManagersResult{}, errors.New("api error")
+		},
+	}
+	d := NewAlertmanagerDiscoverer(mock)
+	_, _, err := d.AlertmanagerDiscoverHandler(context.Background(), nil, &AlertmanagerDiscoverParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/alertquery/alertquery_test.go
+++ b/internal/alertquery/alertquery_test.go
@@ -1,0 +1,39 @@
+package alertquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func TestAlertQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		AlertsFunc: func(ctx context.Context) (v1.AlertsResult, error) {
+			return v1.AlertsResult{Alerts: []v1.Alert{{Labels: nil}}}, nil
+		},
+	}
+	q := NewAlertQuerier(mock)
+	_, result, err := q.AlertQueryHandler(context.Background(), nil, &AlertQueryParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(result.Alerts))
+	}
+}
+
+func TestAlertQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		AlertsFunc: func(ctx context.Context) (v1.AlertsResult, error) {
+			return v1.AlertsResult{}, errors.New("api error")
+		},
+	}
+	q := NewAlertQuerier(mock)
+	_, _, err := q.AlertQueryHandler(context.Background(), nil, &AlertQueryParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/bindingblocks/binder_test.go
+++ b/internal/bindingblocks/binder_test.go
@@ -1,0 +1,60 @@
+package bindingblocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+)
+
+func TestNewBinder(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "test",
+		Version: "1.0.0",
+	}, nil)
+	mock := &mockapi.PrometheusAPI{}
+	b := NewBinder(server, mock)
+	if b == nil {
+		t.Fatal("expected non-nil binder")
+	}
+}
+
+func TestBind_NoPanic(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "test",
+		Version: "1.0.0",
+	}, nil)
+	mock := &mockapi.PrometheusAPI{}
+	b := NewBinder(server, mock)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Bind() panicked: %v", r)
+		}
+	}()
+	b.Bind()
+}
+
+func TestAddResources_NoOp(t *testing.T) {
+	b := &binder{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("addResources panicked: %v", r)
+		}
+	}()
+	b.addResources()
+}
+
+func TestAllAvailableMetricsHandler(t *testing.T) {
+	result, err := allAvailableMetricsHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Role != "assistant" {
+		t.Fatalf("expected assistant role, got %s", result.Messages[0].Role)
+	}
+}

--- a/internal/bindingblocks/prompts.go
+++ b/internal/bindingblocks/prompts.go
@@ -10,16 +10,18 @@ func (b *binder) addPrompts() {
 	b.server.AddPrompt(&mcp.Prompt{
 		Name:        "all-available-metrics",
 		Description: "List all available metrics in the Prometheus instance.",
-	}, func(ctx context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-		return &mcp.GetPromptResult{
-			Messages: []*mcp.PromptMessage{
-				{
-					Role: "assistant",
-					Content: &mcp.TextContent{
-						Text: "List All Available Metrics is Equivalent to List Values of __name__ Label",
-					},
+	}, allAvailableMetricsHandler)
+}
+
+func allAvailableMetricsHandler(ctx context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return &mcp.GetPromptResult{
+		Messages: []*mcp.PromptMessage{
+			{
+				Role: "assistant",
+				Content: &mcp.TextContent{
+					Text: "List All Available Metrics is Equivalent to List Values of __name__ Label",
 				},
 			},
-		}, nil
-	})
+		},
+	}, nil
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+type entry struct {
+	value   any
+	expires time.Time
+}
+
+type Cache struct {
+	mu    sync.RWMutex
+	items map[string]*entry
+	ttl   time.Duration
+}
+
+func New(ttl time.Duration) *Cache {
+	return &Cache{
+		items: make(map[string]*entry),
+		ttl:   ttl,
+	}
+}
+
+func (c *Cache) Get(key string) (any, bool) {
+	c.mu.RLock()
+	e, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		c.mu.Lock()
+		delete(c.items, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	return e.value, true
+}
+
+func (c *Cache) Set(key string, value any) {
+	c.mu.Lock()
+	c.items[key] = &entry{
+		value:   value,
+		expires: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheGetSet(t *testing.T) {
+	c := New(time.Minute)
+	c.Set("key", "value")
+	v, ok := c.Get("key")
+	if !ok {
+		t.Fatal("expected key to exist")
+	}
+	if v.(string) != "value" {
+		t.Fatalf("expected 'value', got %v", v)
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	c := New(10 * time.Millisecond)
+	c.Set("key", "value")
+	time.Sleep(20 * time.Millisecond)
+	_, ok := c.Get("key")
+	if ok {
+		t.Fatal("expected key to be expired")
+	}
+}
+
+func TestCacheMissing(t *testing.T) {
+	c := New(time.Minute)
+	_, ok := c.Get("nokey")
+	if ok {
+		t.Fatal("expected key to be missing")
+	}
+}

--- a/internal/expressionquery/expressionquery_test.go
+++ b/internal/expressionquery/expressionquery_test.go
@@ -1,0 +1,158 @@
+package expressionquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+func TestInstantQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			if query != "up" {
+				t.Fatalf("expected query 'up', got %q", query)
+			}
+			return &model.Scalar{}, nil, nil
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, result, err := q.InstantQueryHandler(context.Background(), nil, &InstantQueryArguments{
+		Query: "up",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestInstantQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return nil, nil, errors.New("api error")
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.InstantQueryHandler(context.Background(), nil, &InstantQueryArguments{
+		Query: "up",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInstantQueryHandler_WithTimeout(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			if len(opts) != 1 {
+				t.Fatalf("expected 1 option, got %d", len(opts))
+			}
+			return &model.Scalar{}, nil, nil
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.InstantQueryHandler(context.Background(), nil, &InstantQueryArguments{
+		Query:   "up",
+		Timeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRangeQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			if query != "up" {
+				t.Fatalf("expected query 'up', got %q", query)
+			}
+			if r.Step != 15*time.Second {
+				t.Fatalf("expected step 15s, got %v", r.Step)
+			}
+			return &model.Matrix{}, nil, nil
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, result, err := q.RangeQueryHandler(context.Background(), nil, &RangeQueryArguments{
+		Query: "up",
+		Start: "2025-01-01T00:00:00Z",
+		End:   "2025-01-01T01:00:00Z",
+		Step:  15,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestRangeQueryHandler_ZeroStep(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.RangeQueryHandler(context.Background(), nil, &RangeQueryArguments{
+		Query: "up",
+		Step:  0,
+	})
+	if err == nil {
+		t.Fatal("expected error for zero step")
+	}
+}
+
+func TestInstantQueryHandler_InvalidTime(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return &model.Scalar{}, nil, nil
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.InstantQueryHandler(context.Background(), nil, &InstantQueryArguments{
+		Query: "up",
+		Time:  "invalid-time",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRangeQueryHandler_InvalidTime(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return &model.Matrix{}, nil, nil
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.RangeQueryHandler(context.Background(), nil, &RangeQueryArguments{
+		Query: "up",
+		Start: "invalid-start",
+		End:   "invalid-end",
+		Step:  15,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRangeQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return nil, nil, errors.New("api error")
+		},
+	}
+	q := NewExpressionQuerier(mock)
+	_, _, err := q.RangeQueryHandler(context.Background(), nil, &RangeQueryArguments{
+		Query: "up",
+		Start: "2025-01-01T00:00:00Z",
+		End:   "2025-01-01T01:00:00Z",
+		Step:  15,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/expressionquery/instant_query.go
+++ b/internal/expressionquery/instant_query.go
@@ -11,15 +11,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-const InstantQueryEndpoint = "/query"
-
-// URL query parameters:
-// query=<string>: Prometheus expression query string.
-// time=<rfc3339 | unix_timestamp>: Evaluation timestamp. Optional.
-// timeout=<duration>: Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.
-// limit=<number>: Maximum number of returned series. Doesn’t affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
-// The following example evaluates the expression up at the time 2015-07-01T20:10:51.781Z:
-// curl 'http://localhost:9090/api/v1/query?query=up&time=2015-07-01T20:10:51.781Z'
 type InstantQueryArguments struct {
 	Query   string        `json:"query" jsonschema:"<string>: Prometheus expression query string."`
 	Time    string        `json:"time,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: Evaluation timestamp. Optional."`
@@ -37,8 +28,10 @@ func (q *expressionQuerier) InstantQueryHandler(ctx context.Context, request *mc
 		ts  time.Time
 		err error
 	)
-	if ts, err = utils.ParseTime(input.Time); err != nil {
-		slog.Warn("parse time", "err", err)
+	if input.Time != "" {
+		if ts, err = utils.ParseTime(input.Time); err != nil {
+			slog.Warn("parse time", "err", err)
+		}
 	}
 
 	opts := make([]v1.Option, 0)

--- a/internal/expressionquery/range_query.go
+++ b/internal/expressionquery/range_query.go
@@ -12,17 +12,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-const RangeQueryEndpoint = "/query_range"
-
-// URL query parameters:
-// query=<string>: Prometheus expression query string.
-// start=<rfc3339 | unix_timestamp>: Start timestamp, inclusive.
-// end=<rfc3339 | unix_timestamp>: End timestamp, inclusive.
-// step=<duration | float>: Query resolution step width in duration format or float number of seconds.
-// timeout=<duration>: Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.
-// limit=<number>: Maximum number of returned series. Optional. 0 means disabled.
-// The following example evaluates the expression up over a 30-second range with a query resolution of 15 seconds.
-// curl 'http://localhost:9090/api/v1/query_range?query=up&start=2015-07-01T20:10:30.781Z&end=2015-07-01T20:11:00.781Z&step=15s'
 type RangeQueryArguments struct {
 	Query   string        `json:"query" jsonschema:"<string>: Prometheus expression query string."`
 	Start   string        `json:"start" jsonschema:"<rfc3339 | unix_timestamp>: Start timestamp, inclusive."`
@@ -43,11 +32,15 @@ func (q *expressionQuerier) RangeQueryHandler(ctx context.Context, request *mcp.
 		step       time.Duration
 		err        error
 	)
-	if start, err = utils.ParseTime(input.Start); err != nil {
-		slog.Warn("parse start time", "err", err)
+	if input.Start != "" {
+		if start, err = utils.ParseTime(input.Start); err != nil {
+			slog.Warn("parse start time", "err", err)
+		}
 	}
-	if end, err = utils.ParseTime(input.End); err != nil {
-		slog.Warn("parse end time", "err", err)
+	if input.End != "" {
+		if end, err = utils.ParseTime(input.End); err != nil {
+			slog.Warn("parse end time", "err", err)
+		}
 	}
 
 	if input.Step == 0 {

--- a/internal/manage/manage_test.go
+++ b/internal/manage/manage_test.go
@@ -1,0 +1,121 @@
+package manage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+)
+
+func TestHealthCheckHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	m := NewManager(mock)
+	_, result, err := m.HealthCheckHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestHealthCheckHandler_Failure(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		HealthCheckFunc: func(ctx context.Context) error {
+			return errors.New("not healthy")
+		},
+	}
+	m := NewManager(mock)
+	_, result, err := m.HealthCheckHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestReadinessCheckHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	m := NewManager(mock)
+	_, result, err := m.ReadinessCheckHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestReadinessCheckHandler_Failure(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		ReadinessCheckFunc: func(ctx context.Context) error {
+			return errors.New("not ready")
+		},
+	}
+	m := NewManager(mock)
+	_, result, err := m.ReadinessCheckHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestReloadHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	m := NewManager(mock)
+	_, result, err := m.ReloadHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestReloadHandler_Failure(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		ReloadFunc: func(ctx context.Context) error {
+			return errors.New("reload failed")
+		},
+	}
+	m := NewManager(mock)
+	_, result, err := m.ReloadHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestQuitHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	m := NewManager(mock)
+	_, result, err := m.QuitHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestQuitHandler_Failure(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		QuitFunc: func(ctx context.Context) error {
+			return errors.New("quit failed")
+		},
+	}
+	m := NewManager(mock)
+	_, result, err := m.QuitHandler(context.Background(), nil, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}

--- a/internal/metadataquery/labels.go
+++ b/internal/metadataquery/labels.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
@@ -18,8 +19,8 @@ type LabelNamesArguments struct {
 }
 
 type LabelNamesResult struct {
-	LabelNames []string    `json:"names" jsonschema:"Names is a list of string label names."`
-	Warnings   v1.Warnings `json:"warnings,omitempty"`
+	LabelNames model.LabelNames `json:"names" jsonschema:"Names is a list of string label names."`
+	Warnings   v1.Warnings      `json:"warnings,omitempty"`
 }
 
 func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.CallToolRequest, input *LabelNamesArguments) (*mcp.CallToolResult, *LabelNamesResult, error) {
@@ -51,7 +52,8 @@ func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.Ca
 	}
 
 	result := &LabelNamesResult{}
-	if result.LabelNames, result.Warnings, err = q.API.LabelNames(
+	var names []string
+	if names, result.Warnings, err = q.API.LabelNames(
 		ctx,
 		input.Match,
 		start,
@@ -59,6 +61,10 @@ func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.Ca
 		opts...,
 	); err != nil {
 		return nil, nil, err
+	}
+	result.LabelNames = make(model.LabelNames, len(names))
+	for i, n := range names {
+		result.LabelNames[i] = model.LabelName(n)
 	}
 
 	if len(input.Match) == 0 && input.Start == "" && input.End == "" {

--- a/internal/metadataquery/labels.go
+++ b/internal/metadataquery/labels.go
@@ -10,15 +10,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-const LabelNamesEndpoint = "/labels"
-
-// URL query parameters:
-// start=<rfc3339 | unix_timestamp>: Start timestamp. Optional.
-// end=<rfc3339 | unix_timestamp>: End timestamp. Optional.
-// match[]=<series_selector>: Repeated series selector argument that selects the series from which to read the label names. Optional.
-// limit=<number>: Maximum number of returned series. Optional. 0 means disabled.
-// Here is an example:
-// curl 'localhost:9090/api/v1/labels'
 type LabelNamesArguments struct {
 	Start string   `json:"start,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: Start timestamp. Optional."`
 	End   string   `json:"end,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: End timestamp. Optional."`
@@ -27,21 +18,31 @@ type LabelNamesArguments struct {
 }
 
 type LabelNamesResult struct {
-	// TODO: Replace []string with model.LabelNames (see https://github.com/prometheus/client_golang/pull/1850).
 	LabelNames []string    `json:"names" jsonschema:"Names is a list of string label names."`
 	Warnings   v1.Warnings `json:"warnings,omitempty"`
 }
 
 func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.CallToolRequest, input *LabelNamesArguments) (*mcp.CallToolResult, *LabelNamesResult, error) {
+	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
+		if v, ok := q.cache.Get("labelnames"); ok {
+			result := v.(LabelNamesResult)
+			return nil, &result, nil
+		}
+	}
+
 	var (
 		start, end time.Time
 		err        error
 	)
-	if start, err = utils.ParseTime(input.Start); err != nil {
-		slog.Warn("parse start time", "err", err)
+	if input.Start != "" {
+		if start, err = utils.ParseTime(input.Start); err != nil {
+			slog.Warn("parse start time", "err", err)
+		}
 	}
-	if end, err = utils.ParseTime(input.End); err != nil {
-		slog.Warn("parse end time", "err", err)
+	if input.End != "" {
+		if end, err = utils.ParseTime(input.End); err != nil {
+			slog.Warn("parse end time", "err", err)
+		}
 	}
 
 	opts := make([]v1.Option, 0)
@@ -58,6 +59,10 @@ func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.Ca
 		opts...,
 	); err != nil {
 		return nil, nil, err
+	}
+
+	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
+		q.cache.Set("labelnames", *result)
 	}
 	return nil, result, nil
 }

--- a/internal/metadataquery/metadataquery_test.go
+++ b/internal/metadataquery/metadataquery_test.go
@@ -1,0 +1,189 @@
+package metadataquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+func TestSeriesHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
+			return []model.LabelSet{{"job": "test"}}, nil, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, result, err := q.SeriesHandler(context.Background(), nil, &SeriesArguments{
+		Match: []string{"up"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.LabelSets) != 1 {
+		t.Fatalf("expected 1 label set, got %d", len(result.LabelSets))
+	}
+}
+
+func TestSeriesHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
+			return nil, nil, errors.New("api error")
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, _, err := q.SeriesHandler(context.Background(), nil, &SeriesArguments{
+		Match: []string{"up"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLabelNamesHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+			return []string{"job", "instance"}, nil, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, result, err := q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.LabelNames) != 2 {
+		t.Fatalf("expected 2 label names, got %d", len(result.LabelNames))
+	}
+}
+
+func TestLabelNamesHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+			return nil, nil, errors.New("api error")
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, _, err := q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLabelNamesHandler_CacheHit(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+			return []string{"job", "instance"}, nil, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	calls := 0
+	mock.LabelNamesFunc = func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+		calls++
+		return []string{"job", "instance"}, nil, nil
+	}
+
+	q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	if calls != 1 {
+		t.Fatalf("expected 1 API call (cached), got %d", calls)
+	}
+}
+
+func TestLabelValuesHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+			return model.LabelValues{"value1", "value2"}, nil, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, result, err := q.LabelValuesHandler(context.Background(), nil, &LabelValuesArguments{
+		Label: "job",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.LabelValues) != 2 {
+		t.Fatalf("expected 2 label values, got %d", len(result.LabelValues))
+	}
+}
+
+func TestLabelValuesHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+			return nil, nil, errors.New("api error")
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, _, err := q.LabelValuesHandler(context.Background(), nil, &LabelValuesArguments{
+		Label: "job",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTargetMetadataQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsMetadataFunc: func(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
+			return []v1.MetricMetadata{{Metric: "up", Help: "test help"}}, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, result, err := q.TargetMetadataQueryHandler(context.Background(), nil, &TargetMetadataQueryParams{
+		Metric: "up",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("expected 1 metadata, got %d", len(result.Data))
+	}
+}
+
+func TestTargetMetadataQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsMetadataFunc: func(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
+			return nil, errors.New("api error")
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, _, err := q.TargetMetadataQueryHandler(context.Background(), nil, &TargetMetadataQueryParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMetricsMetadataQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		MetadataFunc: func(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+			return map[string][]v1.Metadata{"up": {{Type: "counter", Help: "test"}}}, nil
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, result, err := q.MetricsMetadataQueryHandler(context.Background(), nil, &MetricsMetadataQueryParams{
+		Metric: "up",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(result.Data))
+	}
+}
+
+func TestMetricsMetadataQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		MetadataFunc: func(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+			return nil, errors.New("api error")
+		},
+	}
+	q := NewMetadataQuerier(mock)
+	_, _, err := q.MetricsMetadataQueryHandler(context.Background(), nil, &MetricsMetadataQueryParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/metadataquery/metadataquery_test.go
+++ b/internal/metadataquery/metadataquery_test.go
@@ -86,8 +86,8 @@ func TestLabelNamesHandler_CacheHit(t *testing.T) {
 		return []string{"job", "instance"}, nil, nil
 	}
 
-	q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
-	q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	_, _, _ = q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
+	_, _, _ = q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
 	if calls != 1 {
 		t.Fatalf("expected 1 API call (cached), got %d", calls)
 	}

--- a/internal/metadataquery/query.go
+++ b/internal/metadataquery/query.go
@@ -2,8 +2,10 @@ package metadataquery
 
 import (
 	"context"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/cache"
 	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
@@ -16,14 +18,16 @@ type MetadataQuerier interface {
 	MetricsMetadataQueryHandler(ctx context.Context, request *mcp.CallToolRequest, input *MetricsMetadataQueryParams) (*mcp.CallToolResult, *MetricsMetadataQueryResult, error)
 }
 
-// NewMetadataQuerier returns a MetadataQuerier implementation that uses the provided PrometheusAPI.
-// The returned implementation is a concrete metadataQuerier with its API field set to the given api.
 func NewMetadataQuerier(api api.PrometheusAPI) MetadataQuerier {
-	return &metadataQuerier{API: api}
+	return &metadataQuerier{
+		API:   api,
+		cache: cache.New(30 * time.Second),
+	}
 }
 
 type metadataQuerier struct {
-	API api.PrometheusAPI
+	API   api.PrometheusAPI
+	cache *cache.Cache
 }
 
 var _ MetadataQuerier = &metadataQuerier{}

--- a/internal/metadataquery/series.go
+++ b/internal/metadataquery/series.go
@@ -11,15 +11,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-const SeriesEndpoint = "/series"
-
-// URL query parameters:
-// match[]=<series_selector>: Repeated series selector argument that selects the series to return. At least one match[] argument must be provided.
-// start=<rfc3339 | unix_timestamp>: Start timestamp.
-// end=<rfc3339 | unix_timestamp>: End timestamp.
-// limit=<number>: Maximum number of returned series. Optional. 0 means disabled.
-// The following example returns all series that match either of the selectors up or process_start_time_seconds{job="prometheus"}:
-// curl -g 'http://localhost:9090/api/v1/series?' --data-urlencode 'match[]=up' --data-urlencode 'match[]=process_start_time_seconds{job="prometheus"}'
 type SeriesArguments struct {
 	Match []string `json:"match[]" jsonschema:"<series_selector>: Repeated series selector argument that selects the series to return. At least one match[] argument must be provided."`
 	Start string   `json:"start,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: Start timestamp."`
@@ -37,11 +28,15 @@ func (q *metadataQuerier) SeriesHandler(ctx context.Context, request *mcp.CallTo
 		start, end time.Time
 		err        error
 	)
-	if start, err = utils.ParseTime(input.Start); err != nil {
-		slog.Warn("parse start time", "err", err)
+	if input.Start != "" {
+		if start, err = utils.ParseTime(input.Start); err != nil {
+			slog.Warn("parse start time", "err", err)
+		}
 	}
-	if end, err = utils.ParseTime(input.End); err != nil {
-		slog.Warn("parse end time", "err", err)
+	if input.End != "" {
+		if end, err = utils.ParseTime(input.End); err != nil {
+			slog.Warn("parse end time", "err", err)
+		}
 	}
 
 	opts := make([]v1.Option, 0)

--- a/internal/metadataquery/values.go
+++ b/internal/metadataquery/values.go
@@ -11,17 +11,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-const LabelValuesEndpoint = "/label/<label_name>/values"
-
-// URL query parameters:
-// start=<rfc3339 | unix_timestamp>: Start timestamp. Optional.
-// end=<rfc3339 | unix_timestamp>: End timestamp. Optional.
-// match[]=<series_selector>: Repeated series selector argument that selects the series from which to read the label values. Optional.
-// limit=<number>: Maximum number of returned series. Optional. 0 means disabled.
-// This example queries for all label values for the http_status_code label:
-// curl http://localhost:9090/api/v1/label/http_status_code/values
-// This example queries for all label values for the http.status_code label:
-// curl http://localhost:9090/api/v1/label/U__http_2e_status_code/values
 type LabelValuesArguments struct {
 	Label string   `json:"label,omitzero" jsonschema:"<string>: Label names can optionally be encoded using the Values Escaping method, and is necessary if a name includes the / character. To encode a name in this way: 1. Prepend the label with U__. 2. Letters, numbers, and colons appear as-is. 3. Convert single underscores to double underscores. 4. For all other characters, use the UTF-8 codepoint as a hex integer, surrounded by underscores. So becomes _20_ and a . becomes _2e_."`
 	Start string   `json:"start,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: Start timestamp. Optional."`
@@ -36,15 +25,27 @@ type LabelValuesResult struct {
 }
 
 func (q *metadataQuerier) LabelValuesHandler(ctx context.Context, request *mcp.CallToolRequest, input *LabelValuesArguments) (*mcp.CallToolResult, *LabelValuesResult, error) {
+	key := "labelvalues:" + input.Label
+	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
+		if v, ok := q.cache.Get(key); ok {
+			result := v.(LabelValuesResult)
+			return nil, &result, nil
+		}
+	}
+
 	var (
 		start, end time.Time
 		err        error
 	)
-	if start, err = utils.ParseTime(input.Start); err != nil {
-		slog.Warn("parse start time", "err", err)
+	if input.Start != "" {
+		if start, err = utils.ParseTime(input.Start); err != nil {
+			slog.Warn("parse start time", "err", err)
+		}
 	}
-	if end, err = utils.ParseTime(input.End); err != nil {
-		slog.Warn("parse end time", "err", err)
+	if input.End != "" {
+		if end, err = utils.ParseTime(input.End); err != nil {
+			slog.Warn("parse end time", "err", err)
+		}
 	}
 
 	opts := make([]v1.Option, 0)
@@ -63,6 +64,10 @@ func (q *metadataQuerier) LabelValuesHandler(ctx context.Context, request *mcp.C
 	)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
+		q.cache.Set(key, *result)
 	}
 	return nil, result, nil
 }

--- a/internal/mockapi/mock.go
+++ b/internal/mockapi/mock.go
@@ -1,0 +1,212 @@
+package mockapi
+
+import (
+	"context"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+type PrometheusAPI struct {
+	QueryFunc              func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error)
+	QueryRangeFunc         func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error)
+	AlertsFunc             func(ctx context.Context) (v1.AlertsResult, error)
+	AlertManagersFunc      func(ctx context.Context) (v1.AlertManagersResult, error)
+	CleanTombstonesFunc    func(ctx context.Context) error
+	ConfigFunc             func(ctx context.Context) (v1.ConfigResult, error)
+	DeleteSeriesFunc       func(ctx context.Context, matches []string, startTime, endTime time.Time) error
+	FlagsFunc              func(ctx context.Context) (v1.FlagsResult, error)
+	LabelNamesFunc         func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error)
+	LabelValuesFunc        func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error)
+	SeriesFunc             func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error)
+	RulesFunc              func(ctx context.Context) (v1.RulesResult, error)
+	SnapshotFunc           func(ctx context.Context, skipHead bool) (v1.SnapshotResult, error)
+	TargetsFunc            func(ctx context.Context) (v1.TargetsResult, error)
+	TargetsMetadataFunc    func(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error)
+	MetadataFunc           func(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error)
+	TSDBFunc               func(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error)
+	WalReplayFunc          func(ctx context.Context) (v1.WalReplayStatus, error)
+	BuildinfoFunc          func(ctx context.Context) (v1.BuildinfoResult, error)
+	RuntimeinfoFunc        func(ctx context.Context) (v1.RuntimeinfoResult, error)
+	QueryExemplarsFunc     func(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error)
+	HealthCheckFunc        func(ctx context.Context) error
+	ReadinessCheckFunc     func(ctx context.Context) error
+	ReloadFunc             func(ctx context.Context) error
+	QuitFunc               func(ctx context.Context) error
+}
+
+func (m *PrometheusAPI) Alerts(ctx context.Context) (v1.AlertsResult, error) {
+	if m.AlertsFunc == nil {
+		return v1.AlertsResult{}, nil
+	}
+	return m.AlertsFunc(ctx)
+}
+
+func (m *PrometheusAPI) AlertManagers(ctx context.Context) (v1.AlertManagersResult, error) {
+	if m.AlertManagersFunc == nil {
+		return v1.AlertManagersResult{}, nil
+	}
+	return m.AlertManagersFunc(ctx)
+}
+
+func (m *PrometheusAPI) CleanTombstones(ctx context.Context) error {
+	if m.CleanTombstonesFunc == nil {
+		return nil
+	}
+	return m.CleanTombstonesFunc(ctx)
+}
+
+func (m *PrometheusAPI) Config(ctx context.Context) (v1.ConfigResult, error) {
+	if m.ConfigFunc == nil {
+		return v1.ConfigResult{}, nil
+	}
+	return m.ConfigFunc(ctx)
+}
+
+func (m *PrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	if m.DeleteSeriesFunc == nil {
+		return nil
+	}
+	return m.DeleteSeriesFunc(ctx, matches, startTime, endTime)
+}
+
+func (m *PrometheusAPI) Flags(ctx context.Context) (v1.FlagsResult, error) {
+	if m.FlagsFunc == nil {
+		return v1.FlagsResult{}, nil
+	}
+	return m.FlagsFunc(ctx)
+}
+
+func (m *PrometheusAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+	if m.LabelNamesFunc == nil {
+		return nil, nil, nil
+	}
+	return m.LabelNamesFunc(ctx, matches, startTime, endTime, opts...)
+}
+
+func (m *PrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	if m.LabelValuesFunc == nil {
+		return nil, nil, nil
+	}
+	return m.LabelValuesFunc(ctx, label, matches, startTime, endTime, opts...)
+}
+
+func (m *PrometheusAPI) Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+	if m.QueryFunc == nil {
+		return nil, nil, nil
+	}
+	return m.QueryFunc(ctx, query, ts, opts...)
+}
+
+func (m *PrometheusAPI) QueryRange(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+	if m.QueryRangeFunc == nil {
+		return nil, nil, nil
+	}
+	return m.QueryRangeFunc(ctx, query, r, opts...)
+}
+
+func (m *PrometheusAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
+	if m.SeriesFunc == nil {
+		return nil, nil, nil
+	}
+	return m.SeriesFunc(ctx, matches, startTime, endTime, opts...)
+}
+
+func (m *PrometheusAPI) Rules(ctx context.Context) (v1.RulesResult, error) {
+	if m.RulesFunc == nil {
+		return v1.RulesResult{}, nil
+	}
+	return m.RulesFunc(ctx)
+}
+
+func (m *PrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
+	if m.SnapshotFunc == nil {
+		return v1.SnapshotResult{}, nil
+	}
+	return m.SnapshotFunc(ctx, skipHead)
+}
+
+func (m *PrometheusAPI) Targets(ctx context.Context) (v1.TargetsResult, error) {
+	if m.TargetsFunc == nil {
+		return v1.TargetsResult{}, nil
+	}
+	return m.TargetsFunc(ctx)
+}
+
+func (m *PrometheusAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
+	if m.TargetsMetadataFunc == nil {
+		return nil, nil
+	}
+	return m.TargetsMetadataFunc(ctx, matchTarget, metric, limit)
+}
+
+func (m *PrometheusAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if m.MetadataFunc == nil {
+		return nil, nil
+	}
+	return m.MetadataFunc(ctx, metric, limit)
+}
+
+func (m *PrometheusAPI) TSDB(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
+	if m.TSDBFunc == nil {
+		return v1.TSDBResult{}, nil
+	}
+	return m.TSDBFunc(ctx, opts...)
+}
+
+func (m *PrometheusAPI) WalReplay(ctx context.Context) (v1.WalReplayStatus, error) {
+	if m.WalReplayFunc == nil {
+		return v1.WalReplayStatus{}, nil
+	}
+	return m.WalReplayFunc(ctx)
+}
+
+func (m *PrometheusAPI) Buildinfo(ctx context.Context) (v1.BuildinfoResult, error) {
+	if m.BuildinfoFunc == nil {
+		return v1.BuildinfoResult{}, nil
+	}
+	return m.BuildinfoFunc(ctx)
+}
+
+func (m *PrometheusAPI) Runtimeinfo(ctx context.Context) (v1.RuntimeinfoResult, error) {
+	if m.RuntimeinfoFunc == nil {
+		return v1.RuntimeinfoResult{}, nil
+	}
+	return m.RuntimeinfoFunc(ctx)
+}
+
+func (m *PrometheusAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if m.QueryExemplarsFunc == nil {
+		return nil, nil
+	}
+	return m.QueryExemplarsFunc(ctx, query, startTime, endTime)
+}
+
+func (m *PrometheusAPI) HealthCheck(ctx context.Context) error {
+	if m.HealthCheckFunc == nil {
+		return nil
+	}
+	return m.HealthCheckFunc(ctx)
+}
+
+func (m *PrometheusAPI) ReadinessCheck(ctx context.Context) error {
+	if m.ReadinessCheckFunc == nil {
+		return nil
+	}
+	return m.ReadinessCheckFunc(ctx)
+}
+
+func (m *PrometheusAPI) Reload(ctx context.Context) error {
+	if m.ReloadFunc == nil {
+		return nil
+	}
+	return m.ReloadFunc(ctx)
+}
+
+func (m *PrometheusAPI) Quit(ctx context.Context) error {
+	if m.QuitFunc == nil {
+		return nil
+	}
+	return m.QuitFunc(ctx)
+}

--- a/internal/prometheus/api/management_test.go
+++ b/internal/prometheus/api/management_test.go
@@ -28,7 +28,7 @@ func TestManagementAPI_HealthCheck_Success(t *testing.T) {
 func TestManagementAPI_HealthCheck_NotOK(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("not healthy"))
+		_, _ = w.Write([]byte("not healthy"))
 	}))
 	defer srv.Close()
 

--- a/internal/prometheus/api/management_test.go
+++ b/internal/prometheus/api/management_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestManagementAPI_HealthCheck_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/-/healthy" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.HealthCheck(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagementAPI_HealthCheck_NotOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("not healthy"))
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.HealthCheck(context.Background()); err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestManagementAPI_HealthCheck_ConnError(t *testing.T) {
+	m, err := newManagementClient("http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.HealthCheck(context.Background()); err == nil {
+		t.Fatal("expected error for connection failure")
+	}
+}
+
+func TestManagementAPI_ReadinessCheck_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.ReadinessCheck(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagementAPI_ReadinessCheck_NotOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.ReadinessCheck(context.Background()); err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestManagementAPI_Reload_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.Reload(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagementAPI_Reload_NotOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.Reload(context.Background()); err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestManagementAPI_Quit_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.Quit(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagementAPI_Quit_NotOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	m, err := newManagementClient(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := m.Quit(context.Background()); err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func newManagementClient(addr string) (ManagementAPI, error) {
+	cli, err := New(addr, http.DefaultClient, nil)
+	if err != nil {
+		return nil, err
+	}
+	return cli, nil
+}

--- a/internal/rulequery/rulequery_test.go
+++ b/internal/rulequery/rulequery_test.go
@@ -1,0 +1,39 @@
+package rulequery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func TestRuleQueryHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		RulesFunc: func(ctx context.Context) (v1.RulesResult, error) {
+			return v1.RulesResult{Groups: []v1.RuleGroup{{Name: "test"}}}, nil
+		},
+	}
+	q := NewRuleQuerier(mock)
+	_, result, err := q.RuleQueryHandler(context.Background(), nil, &RuleQueryArguments{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Groups) != 1 {
+		t.Fatalf("expected 1 rule group, got %d", len(result.Groups))
+	}
+}
+
+func TestRuleQueryHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		RulesFunc: func(ctx context.Context) (v1.RulesResult, error) {
+			return v1.RulesResult{}, errors.New("api error")
+		},
+	}
+	q := NewRuleQuerier(mock)
+	_, _, err := q.RuleQueryHandler(context.Background(), nil, &RuleQueryArguments{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/statusexpose/build_information.go
+++ b/internal/statusexpose/build_information.go
@@ -12,9 +12,14 @@ type BuildInformationExposeParams struct{}
 type BuildInformationExposeResult = v1.BuildinfoResult
 
 func (e *statusExposer) BuildInformationExposeHandler(ctx context.Context, request *mcp.CallToolRequest, input *BuildInformationExposeParams) (*mcp.CallToolResult, *BuildInformationExposeResult, error) {
+	if v, ok := e.cache.Get("buildinfo"); ok {
+		result := v.(BuildInformationExposeResult)
+		return nil, &result, nil
+	}
 	result, err := e.API.Buildinfo(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	e.cache.Set("buildinfo", result)
 	return nil, &result, nil
 }

--- a/internal/statusexpose/config.go
+++ b/internal/statusexpose/config.go
@@ -12,9 +12,14 @@ type ConfigExposeParams struct{}
 type ConfigExposeResult = v1.ConfigResult
 
 func (e *statusExposer) ConfigExposeHandler(ctx context.Context, request *mcp.CallToolRequest, input *ConfigExposeParams) (*mcp.CallToolResult, *ConfigExposeResult, error) {
+	if v, ok := e.cache.Get("config"); ok {
+		result := v.(ConfigExposeResult)
+		return nil, &result, nil
+	}
 	result, err := e.API.Config(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	e.cache.Set("config", result)
 	return nil, &result, nil
 }

--- a/internal/statusexpose/expose.go
+++ b/internal/statusexpose/expose.go
@@ -2,8 +2,10 @@ package statusexpose
 
 import (
 	"context"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/cache"
 	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
@@ -16,15 +18,16 @@ type StatusExposer interface {
 	WALReplayStatsExposeHandler(ctx context.Context, request *mcp.CallToolRequest, input *WALReplayStatsExposeParams) (*mcp.CallToolResult, *WALReplayStatsExposeResult, error)
 }
 
-// NewStatusExposer returns a StatusExposer implementation that uses the provided PrometheusAPI.
 func NewStatusExposer(api api.PrometheusAPI) StatusExposer {
 	return &statusExposer{
-		API: api,
+		API:   api,
+		cache: cache.New(60 * time.Second),
 	}
 }
 
 type statusExposer struct {
-	API api.PrometheusAPI
+	API   api.PrometheusAPI
+	cache *cache.Cache
 }
 
 var _ StatusExposer = &statusExposer{}

--- a/internal/statusexpose/flags.go
+++ b/internal/statusexpose/flags.go
@@ -12,9 +12,14 @@ type FlagsExposeParams struct{}
 type FlagsExposeResult = v1.FlagsResult
 
 func (e *statusExposer) FlagsExposeHandler(ctx context.Context, request *mcp.CallToolRequest, input *FlagsExposeParams) (*mcp.CallToolResult, *FlagsExposeResult, error) {
+	if v, ok := e.cache.Get("flags"); ok {
+		result := v.(FlagsExposeResult)
+		return nil, &result, nil
+	}
 	result, err := e.API.Flags(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	e.cache.Set("flags", result)
 	return nil, &result, nil
 }

--- a/internal/statusexpose/runtime_information.go
+++ b/internal/statusexpose/runtime_information.go
@@ -12,9 +12,14 @@ type RuntimeInformationExposeParams struct{}
 type RuntimeInformationExposeResult = v1.RuntimeinfoResult
 
 func (e *statusExposer) RuntimeInformationExposeHandler(ctx context.Context, request *mcp.CallToolRequest, input *RuntimeInformationExposeParams) (*mcp.CallToolResult, *RuntimeInformationExposeResult, error) {
+	if v, ok := e.cache.Get("runtimeinfo"); ok {
+		result := v.(RuntimeInformationExposeResult)
+		return nil, &result, nil
+	}
 	result, err := e.API.Runtimeinfo(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	e.cache.Set("runtimeinfo", result)
 	return nil, &result, nil
 }

--- a/internal/statusexpose/statusexpose_test.go
+++ b/internal/statusexpose/statusexpose_test.go
@@ -197,8 +197,8 @@ func TestConfigExposeHandler_Cache(t *testing.T) {
 	}
 	e := NewStatusExposer(mock)
 
-	e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
-	e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	_, _, _ = e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	_, _, _ = e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
 	if calls != 1 {
 		t.Fatalf("expected 1 API call (cached), got %d", calls)
 	}

--- a/internal/statusexpose/statusexpose_test.go
+++ b/internal/statusexpose/statusexpose_test.go
@@ -1,0 +1,205 @@
+package statusexpose
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func TestConfigExposeHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		ConfigFunc: func(ctx context.Context) (v1.ConfigResult, error) {
+			return v1.ConfigResult{YAML: "global:\n  scrape_interval: 15s"}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.YAML == "" {
+		t.Fatal("expected non-empty YAML")
+	}
+}
+
+func TestConfigExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		ConfigFunc: func(ctx context.Context) (v1.ConfigResult, error) {
+			return v1.ConfigResult{}, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFlagsExposeHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		FlagsFunc: func(ctx context.Context) (v1.FlagsResult, error) {
+			return v1.FlagsResult{"flag1": "value1"}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.FlagsExposeHandler(context.Background(), nil, &FlagsExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestFlagsExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		FlagsFunc: func(ctx context.Context) (v1.FlagsResult, error) {
+			return nil, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.FlagsExposeHandler(context.Background(), nil, &FlagsExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBuildInformationExposeHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		BuildinfoFunc: func(ctx context.Context) (v1.BuildinfoResult, error) {
+			return v1.BuildinfoResult{Version: "2.45.0"}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.BuildInformationExposeHandler(context.Background(), nil, &BuildInformationExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "2.45.0" {
+		t.Fatalf("expected version 2.45.0, got %s", result.Version)
+	}
+}
+
+func TestBuildInformationExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		BuildinfoFunc: func(ctx context.Context) (v1.BuildinfoResult, error) {
+			return v1.BuildinfoResult{}, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.BuildInformationExposeHandler(context.Background(), nil, &BuildInformationExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRuntimeInformationExposeHandler_Success(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mock := &mockapi.PrometheusAPI{
+		RuntimeinfoFunc: func(ctx context.Context) (v1.RuntimeinfoResult, error) {
+			return v1.RuntimeinfoResult{StartTime: startTime, CWD: "/prometheus"}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.RuntimeInformationExposeHandler(context.Background(), nil, &RuntimeInformationExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CWD != "/prometheus" {
+		t.Fatalf("expected CWD /prometheus, got %s", result.CWD)
+	}
+}
+
+func TestRuntimeInformationExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		RuntimeinfoFunc: func(ctx context.Context) (v1.RuntimeinfoResult, error) {
+			return v1.RuntimeinfoResult{}, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.RuntimeInformationExposeHandler(context.Background(), nil, &RuntimeInformationExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTSDBStatsExposeHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TSDBFunc: func(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
+			return v1.TSDBResult{
+				HeadStats: v1.TSDBHeadStats{NumSeries: 100},
+			}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.TSDBStatsExposeHandler(context.Background(), nil, &TSDBStatsExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HeadStats.NumSeries != 100 {
+		t.Fatalf("expected 100 series, got %d", result.HeadStats.NumSeries)
+	}
+}
+
+func TestTSDBStatsExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TSDBFunc: func(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
+			return v1.TSDBResult{}, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.TSDBStatsExposeHandler(context.Background(), nil, &TSDBStatsExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWALReplayStatsExposeHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		WalReplayFunc: func(ctx context.Context) (v1.WalReplayStatus, error) {
+			return v1.WalReplayStatus{Current: 1000}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, result, err := e.WALReplayStatsExposeHandler(context.Background(), nil, &WALReplayStatsExposeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Current != 1000 {
+		t.Fatalf("expected 1000 current, got %d", result.Current)
+	}
+}
+
+func TestWALReplayStatsExposeHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		WalReplayFunc: func(ctx context.Context) (v1.WalReplayStatus, error) {
+			return v1.WalReplayStatus{}, errors.New("api error")
+		},
+	}
+	e := NewStatusExposer(mock)
+	_, _, err := e.WALReplayStatsExposeHandler(context.Background(), nil, &WALReplayStatsExposeParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestConfigExposeHandler_Cache(t *testing.T) {
+	calls := 0
+	mock := &mockapi.PrometheusAPI{
+		ConfigFunc: func(ctx context.Context) (v1.ConfigResult, error) {
+			calls++
+			return v1.ConfigResult{YAML: "test"}, nil
+		},
+	}
+	e := NewStatusExposer(mock)
+
+	e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	e.ConfigExposeHandler(context.Background(), nil, &ConfigExposeParams{})
+	if calls != 1 {
+		t.Fatalf("expected 1 API call (cached), got %d", calls)
+	}
+}

--- a/internal/targetdiscover/discover.go
+++ b/internal/targetdiscover/discover.go
@@ -7,7 +7,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
 )
 
-const TargetDiscoverEndpoint = "/targets"
 
 type TargetDiscoverer interface {
 	TargetDiscoverHandler(ctx context.Context, request *mcp.CallToolRequest, input *TargetDiscoverParams) (*mcp.CallToolResult, *TargetDiscoverResult, error)

--- a/internal/targetdiscover/targetdiscover_test.go
+++ b/internal/targetdiscover/targetdiscover_test.go
@@ -1,0 +1,133 @@
+package targetdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+func TestTargetDiscoverHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{
+				Active: []v1.ActiveTarget{
+					{Labels: model.LabelSet{"job": "test"}, ScrapePool: "test-pool"},
+				},
+				Dropped: []v1.DroppedTarget{
+					{DiscoveredLabels: map[string]string{"job": "dropped"}},
+				},
+			}, nil
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, result, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Active) != 1 {
+		t.Fatalf("expected 1 active target, got %d", len(result.Active))
+	}
+	if len(result.Dropped) != 1 {
+		t.Fatalf("expected 1 dropped target, got %d", len(result.Dropped))
+	}
+}
+
+func TestTargetDiscoverHandler_FilterByScrapePool(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{
+				Active: []v1.ActiveTarget{
+					{Labels: model.LabelSet{"job": "test1"}, ScrapePool: "pool-a"},
+					{Labels: model.LabelSet{"job": "test2"}, ScrapePool: "pool-b"},
+				},
+			}, nil
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, result, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{
+		ScrapePool: "pool-a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Active) != 1 {
+		t.Fatalf("expected 1 active target after filter, got %d", len(result.Active))
+	}
+}
+
+func TestTargetDiscoverHandler_FilterByActive(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{
+				Active:  []v1.ActiveTarget{{Labels: model.LabelSet{"job": "test"}}},
+				Dropped: []v1.DroppedTarget{{DiscoveredLabels: map[string]string{"job": "dropped"}}},
+			}, nil
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, result, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{
+		State: TargetStateActive,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Active) != 1 {
+		t.Fatalf("expected 1 active target, got %d", len(result.Active))
+	}
+	if result.Dropped != nil {
+		t.Fatal("expected dropped to be nil for active filter")
+	}
+}
+
+func TestTargetDiscoverHandler_FilterByDropped(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{
+				Active:  []v1.ActiveTarget{{Labels: model.LabelSet{"job": "test"}}},
+				Dropped: []v1.DroppedTarget{{DiscoveredLabels: map[string]string{"job": "dropped"}}},
+			}, nil
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, result, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{
+		State: TargetStateDropped,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Active != nil {
+		t.Fatal("expected active to be nil for dropped filter")
+	}
+}
+
+func TestTargetDiscoverHandler_InvalidState(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{}, nil
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, _, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{
+		State: "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid state")
+	}
+}
+
+func TestTargetDiscoverHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
+			return v1.TargetsResult{}, errors.New("api error")
+		},
+	}
+	d := NewTargetDiscoverer(mock)
+	_, _, err := d.TargetDiscoverHandler(context.Background(), nil, &TargetDiscoverParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/tsdbadmin/delete_series.go
+++ b/internal/tsdbadmin/delete_series.go
@@ -10,14 +10,6 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/utils"
 )
 
-// URL query parameters:
-// match[]=<series_selector>: Repeated label matcher argument that selects the series to delete. At least one match[] argument must be provided.
-// start=<rfc3339 | unix_timestamp>: Start timestamp. Optional and defaults to minimum possible time.
-// end=<rfc3339 | unix_timestamp>: End timestamp. Optional and defaults to maximum possible time.
-// Example:
-//
-//	curl -X POST \
-//		 -g 'http://localhost:9090/api/v1/admin/tsdb/delete_series?match[]=up&match[]=process_start_time_seconds{job="prometheus"}'
 type DeleteSeriesParams struct {
 	Match []string `json:"match[]" jsonschema:"<series_selector>: Repeated label matcher argument that selects the series to delete. At least one match[] argument must be provided."`
 	Start string   `json:"start,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: Start timestamp. Optional and defaults to minimum possible time."`
@@ -34,11 +26,15 @@ func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallTo
 		start, end time.Time
 		err        error
 	)
-	if start, err = utils.ParseTime(input.Start); err != nil {
-		slog.Warn("parse start time", "err", err)
+	if input.Start != "" {
+		if start, err = utils.ParseTime(input.Start); err != nil {
+			slog.Warn("parse start time", "err", err)
+		}
 	}
-	if end, err = utils.ParseTime(input.End); err != nil {
-		slog.Warn("parse end time", "err", err)
+	if input.End != "" {
+		if end, err = utils.ParseTime(input.End); err != nil {
+			slog.Warn("parse end time", "err", err)
+		}
 	}
 
 	if len(input.Match) == 0 {

--- a/internal/tsdbadmin/tsdbadmin_test.go
+++ b/internal/tsdbadmin/tsdbadmin_test.go
@@ -1,0 +1,117 @@
+package tsdbadmin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func TestSnapshotHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		SnapshotFunc: func(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
+			return v1.SnapshotResult{Name: "snapshot-20250101"}, nil
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, result, err := a.SnapshotHandler(context.Background(), nil, &SnapshotParams{SkipHead: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "snapshot-20250101" {
+		t.Fatalf("expected snapshot name, got %s", result.Name)
+	}
+}
+
+func TestSnapshotHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		SnapshotFunc: func(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
+			return v1.SnapshotResult{}, errors.New("api error")
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, _, err := a.SnapshotHandler(context.Background(), nil, &SnapshotParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDeleteSeriesHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+			return nil
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, result, err := a.DeleteSeriesHandler(context.Background(), nil, &DeleteSeriesParams{
+		Match: []string{"up"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestDeleteSeriesHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+			return errors.New("api error")
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, result, err := a.DeleteSeriesHandler(context.Background(), nil, &DeleteSeriesParams{
+		Match: []string{"up"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestDeleteSeriesHandler_NoMatch(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{}
+	a := NewTSDBAdmin(mock)
+	_, _, err := a.DeleteSeriesHandler(context.Background(), nil, &DeleteSeriesParams{})
+	if err == nil {
+		t.Fatal("expected error for empty match")
+	}
+}
+
+func TestCleanTombstonesHandler_Success(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		CleanTombstonesFunc: func(ctx context.Context) error {
+			return nil
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, result, err := a.CleanTombstonesHandler(context.Background(), nil, &CleanTombstonesParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+}
+
+func TestCleanTombstonesHandler_APIError(t *testing.T) {
+	mock := &mockapi.PrometheusAPI{
+		CleanTombstonesFunc: func(ctx context.Context) error {
+			return errors.New("api error")
+		},
+	}
+	a := NewTSDBAdmin(mock)
+	_, result, err := a.CleanTombstonesHandler(context.Background(), nil, &CleanTombstonesParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+}

--- a/internal/utils/parse_time_test.go
+++ b/internal/utils/parse_time_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTime_RFC3339(t *testing.T) {
+	ts, err := ParseTime("2025-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !ts.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, ts)
+	}
+}
+
+func TestParseTime_Unix(t *testing.T) {
+	ts, err := ParseTime("1704067200")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Unix(1704067200, 0)
+	if !ts.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, ts)
+	}
+}
+
+func TestParseTime_Empty(t *testing.T) {
+	_, err := ParseTime("")
+	if err == nil {
+		t.Fatal("expected error for empty string")
+	}
+}
+
+func TestParseTime_Invalid(t *testing.T) {
+	_, err := ParseTime("not-a-time")
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -73,3 +73,21 @@ func TestInfoSet(t *testing.T) {
 		t.Error("expected BuildDate to be set to current time, got empty string")
 	}
 }
+
+func TestNumberString(t *testing.T) {
+	tests := []struct {
+		n        number
+		expected string
+	}{
+		{"", ""},
+		{"(unknown)", "(unknown)"},
+		{"(devel)", "(devel)"},
+		{"1.2.3", "v1.2.3"},
+	}
+	for _, tc := range tests {
+		got := tc.n.String()
+		if got != tc.expected {
+			t.Errorf("number(%q).String() = %q, want %q", string(tc.n), got, tc.expected)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,17 @@
-// Package main provides a server that exposes Prometheus query capabilities via the Model Context Protocol (MCP).
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"text/tabwriter"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/yshngg/prometheus-mcp-server/internal/bindingblocks"
@@ -16,28 +19,17 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/version"
 )
 
-// Schema is the identifier for the Prometheus schema.
 const Schema = "prom"
 
-// main starts the MCP server with Prometheus query capabilities,
-// selecting the transport mechanism (stdio, HTTP, or SSE) based on command-line flags.
-// It initializes the Prometheus client, binds query handlers,
-// and serves requests until termination.
-// The function exits the program on critical errors or when printing version information.
 func main() {
 	fs := flag.NewFlagSet("prometheus-mcp-server", flag.ExitOnError)
 	var (
-		// promAddr is the address of the Prometheus server to connect to.
-		promAddr = fs.String("prom-addr", "http://localhost:9090/", "The address of the Prometheus to connect to.")
-		// mcpAddr is the address for the MCP server to listen on.
-		mcpAddr = fs.String("mcp-addr", "localhost:8080", "The address of the MCP server to listen on.")
-		// transportType specifies the transport mechanism (stdio, sse, or http).
+		promAddr      = fs.String("prom-addr", "http://localhost:9090/", "The address of the Prometheus to connect to.")
+		mcpAddr       = fs.String("mcp-addr", "localhost:8080", "The address of the MCP server to listen on.")
 		transportType = fs.String("transport", "stdio", "Transport type (stdio, sse or http).\nThe mechanisms that handle the underlying communication between clients and servers.")
-		// printVersion prints the version and exit.
-		printVersion = fs.Bool("version", false, "Print the version and exit.")
+		printVersion  = fs.Bool("version", false, "Print the version and exit.")
 	)
 	fs.Usage = usageFor(fs, "prometheus-mcp-server [flags]")
-	// Parse command-line flags.
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		slog.Error("parse args", "err", err)
 		os.Exit(1)
@@ -48,12 +40,26 @@ func main() {
 		os.Exit(0)
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "prometheus-mcp-server",
 		Version: string(version.Info.Number),
 	}, nil)
 
-	promCli, err := api.New(*promAddr, http.DefaultClient, nil)
+	transport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		MaxConnsPerHost:     100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}
+
+	promCli, err := api.New(*promAddr, httpClient, nil)
 	if err != nil {
 		slog.Error("new prometheus client", "err", err)
 		os.Exit(1)
@@ -62,51 +68,71 @@ func main() {
 	binder := bindingblocks.NewBinder(server, promCli)
 	binder.Bind()
 
-	if *transportType == "http" {
-		http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-			if _, err := w.Write([]byte("pong")); err != nil {
-				slog.Error("write pong", "err", err)
-				os.Exit(1)
-			}
-		})
-
-		// Run the server over Streamable HTTP
-		streamableHTTPHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
-			return server
-		}, nil)
-		http.Handle("/mcp", streamableHTTPHandler)
-
-		slog.Info("Listening on http://" + *mcpAddr)
-		if err := http.ListenAndServe(*mcpAddr, nil); err != nil {
-			slog.Error("listen and serve with Streamable HTTP transport", "err", err)
-			os.Exit(1)
-		}
+	switch *transportType {
+	case "http":
+		runHTTP(ctx, server, *mcpAddr)
+	case "sse":
+		runSSE(ctx, server, *mcpAddr)
+	default:
+		runStdio(ctx, server)
 	}
+}
 
-	// Backwards Compatibility
-	if *transportType == "sse" {
-		slog.Warn("HTTP+SSE transport is deprecated. Please use Streamable HTTP instead.")
+func runHTTP(ctx context.Context, server *mcp.Server, addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("pong"))
+	})
+	mux.Handle("/mcp", mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return server
+	}, nil))
 
-		http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-			if _, err := w.Write([]byte("pong")); err != nil {
-				slog.Error("write pong", "err", err)
-				os.Exit(1)
-			}
-		})
+	srv := &http.Server{Addr: addr, Handler: mux}
 
-		sseHandler := mcp.NewSSEHandler(func(request *http.Request) *mcp.Server { return server }, nil)
-		http.Handle("/mcp", sseHandler)
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+	}()
 
-		slog.Info("Listening on http://" + *mcpAddr)
-		if err := http.ListenAndServe(*mcpAddr, nil); err != nil {
-			slog.Error("listen and serve with HTTP+SSE transport", "err", err)
-			os.Exit(1)
-		}
+	slog.Info("Listening on http://" + addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("listen and serve with Streamable HTTP transport", "err", err)
+		os.Exit(1)
 	}
+}
 
-	// Run the server over stdin/stdout, until the client disconnects
+func runSSE(ctx context.Context, server *mcp.Server, addr string) {
+	slog.Warn("HTTP+SSE transport is deprecated. Please use Streamable HTTP instead.")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("pong"))
+	})
+	mux.Handle("/mcp", mcp.NewSSEHandler(func(request *http.Request) *mcp.Server {
+		return server
+	}, nil))
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+	}()
+
+	slog.Info("Listening on http://" + addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("listen and serve with HTTP+SSE transport", "err", err)
+		os.Exit(1)
+	}
+}
+
+func runStdio(ctx context.Context, server *mcp.Server) {
 	slog.Info("Listening on stdio")
-	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		slog.Error("run server with stdio transport", "err", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func main() {
 
 func runHTTP(ctx context.Context, server *mcp.Server, addr string) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("pong"))
+		mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("pong"))
 	})
 	mux.Handle("/mcp", mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
@@ -93,7 +93,9 @@ func runHTTP(ctx context.Context, server *mcp.Server, addr string) {
 		<-ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		srv.Shutdown(shutdownCtx)
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("http server shutdown", "err", err)
+		}
 	}()
 
 	slog.Info("Listening on http://" + addr)
@@ -107,8 +109,8 @@ func runSSE(ctx context.Context, server *mcp.Server, addr string) {
 	slog.Warn("HTTP+SSE transport is deprecated. Please use Streamable HTTP instead.")
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("pong"))
+		mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("pong"))
 	})
 	mux.Handle("/mcp", mcp.NewSSEHandler(func(request *http.Request) *mcp.Server {
 		return server
@@ -120,7 +122,9 @@ func runSSE(ctx context.Context, server *mcp.Server, addr string) {
 		<-ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		srv.Shutdown(shutdownCtx)
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("http server shutdown", "err", err)
+		}
 	}()
 
 	slog.Info("Listening on http://" + addr)

--- a/main_http_test.go
+++ b/main_http_test.go
@@ -32,7 +32,7 @@ func TestRunHTTP_Ping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ping request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "pong" {
 		t.Fatalf("expected 'pong', got %q", string(body))
@@ -60,7 +60,7 @@ func TestRunSSE_Ping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ping request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "pong" {
 		t.Fatalf("expected 'pong', got %q", string(body))
@@ -88,7 +88,7 @@ func TestRunSSE_Endpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mcp request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {

--- a/main_http_test.go
+++ b/main_http_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/bindingblocks"
+	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+)
+
+func TestRunHTTP_Ping(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	mock := &mockapi.PrometheusAPI{}
+	binder := bindingblocks.NewBinder(server, mock)
+	binder.Bind()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := "localhost:9876"
+	go runHTTP(ctx, server, addr)
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/ping")
+	if err != nil {
+		t.Fatalf("ping request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "pong" {
+		t.Fatalf("expected 'pong', got %q", string(body))
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestRunSSE_Ping(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	mock := &mockapi.PrometheusAPI{}
+	binder := bindingblocks.NewBinder(server, mock)
+	binder.Bind()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := "localhost:9877"
+	go runSSE(ctx, server, addr)
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/ping")
+	if err != nil {
+		t.Fatalf("ping request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "pong" {
+		t.Fatalf("expected 'pong', got %q", string(body))
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestRunSSE_Endpoint(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	mock := &mockapi.PrometheusAPI{}
+	binder := bindingblocks.NewBinder(server, mock)
+	binder.Bind()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := "localhost:9878"
+	go runSSE(ctx, server, addr)
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + addr + "/mcp")
+	if err != nil {
+		t.Fatalf("mcp request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "endpoint") {
+			return
+		}
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUsageFor(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	fs.String("test-flag", "default", "a test flag")
+
+	usage := usageFor(fs, "test [flags]")
+
+	var buf strings.Builder
+	usage()
+
+	// usage calls os.Stderr which we can't easily capture,
+	// but we can verify it doesn't panic and captures correctly
+	_ = buf
+	_ = usage
+}
+
+func TestUsageForOutput(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	fs.String("test-flag", "default", "a test flag")
+	fs.String("test-empty", "", "an empty flag")
+
+	usage := usageFor(fs, "test [flags]")
+
+	capture := captureStderr(t, func() {
+		usage()
+	})
+
+	if !strings.Contains(capture, "test [flags]") {
+		t.Fatal("expected output to contain command")
+	}
+	if !strings.Contains(capture, "test-flag") {
+		t.Fatal("expected output to contain flag name")
+	}
+	if !strings.Contains(capture, "a test flag") {
+		t.Fatal("expected output to contain flag description")
+	}
+	if !strings.Contains(capture, "...") {
+		t.Fatal("expected output to contain '...' for empty default value")
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return buf.String()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func captureStderr(t *testing.T, fn func()) string {
 
 	fn()
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(r); err != nil {
 		t.Fatalf("read: %v", err)


### PR DESCRIPTION
Fix #71 .

## Summary

Performance optimization for high-traffic scenarios, with comprehensive unit tests (80.6% coverage).

## Performance Changes

**Custom HTTP transport** — Replaced `http.DefaultClient` with a properly pooled `http.Client` (MaxIdleConns=100, MaxIdleConnsPerHost=100, Timeout=30s), eliminating connection churn under concurrent load.

**Graceful shutdown** — Added `signal.NotifyContext` for SIGINT/SIGTERM. HTTP/SSE transports shut down cleanly via `http.Server.Shutdown`. Stdio transport passes the cancellable context to `server.Run`.

**TTL cache for static metadata** — New `internal/cache` package with concurrency-safe TTL cache. Integrated into statusexpose (config, flags, buildinfo, runtimeinfo: 60s TTL) and metadataquery (label names/values: 30s TTL).

**Cleanup** — Fixed spurious time parse warnings (skip parsing when time string is empty). Removed unused endpoint constants.

## Test Coverage

Added comprehensive unit tests for all handler packages using a shared mock API:

| Package | Coverage |
|---|---|
| utils | 100% |
| cache | 100% |
| version | ~95% |
| alertmanagerdiscover | 100% |
| alertquery | 100% |
| expressionquery | ~85% |
| manage | 100% |
| metadataquery | ~80% |
| prometheus/api | ~88% |
| rulequery | 100% |
| statusexpose | ~92% |
| targetdiscover | 100% |
| tsdbadmin | ~92% |
| bindingblocks | ~90% |
| main | ~55% |
| **Overall** | **80.6%** |