### PR TITLE
refactor: architecture overhaul — directory restructure, design patterns, bugfixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,9 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X {{ .ModulePath }}/internal/version.Number={{ .Version }}
-      - -X {{ .ModulePath }}/internal/version.GitCommit={{ .Commit }}
-      - -X {{ .ModulePath }}/internal/version.BuildDate={{ .Date }}
+      - -X {{ .ModulePath }}/internal/buildinfo.Number={{ .Version }}
+      - -X {{ .ModulePath }}/internal/buildinfo.GitCommit={{ .Commit }}
+      - -X {{ .ModulePath }}/internal/buildinfo.BuildDate={{ .Date }}
     
     # GOOS list to build for.
     # For more info refer to: https://internal.go.dev/cmd/go#hdr-Environment_variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -o prometheus-mcp-server \
-    -ldflags="-s -w -X 'github.com/yshngg/prometheus-mcp-server/internal/version.Number=${VERSION_NUMBER}' -X 'github.com/yshngg/prometheus-mcp-server/internal/version.GitCommit=${GIT_COMMIT}' -X 'github.com/yshngg/prometheus-mcp-server/internal/version.BuildDate=${BUILD_DATE}'" \
+    -ldflags="-s -w -X 'github.com/yshngg/prometheus-mcp-server/internal/buildinfo.Number=${VERSION_NUMBER}' -X 'github.com/yshngg/prometheus-mcp-server/internal/buildinfo.GitCommit=${GIT_COMMIT}' -X 'github.com/yshngg/prometheus-mcp-server/internal/buildinfo.BuildDate=${BUILD_DATE}'" \
     .
 
 # Final image

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ PACKAGE := $(shell go list -m)
 
 # Build flags
 LDFLAGS := -s -w
-LDFLAGS += -X $(PACKAGE)/internal/version.Number=$(VERSION)
-LDFLAGS += -X $(PACKAGE)/internal/version.GitCommit=$(GIT_COMMIT)
-LDFLAGS += -X $(PACKAGE)/internal/version.BuildDate=$(BUILD_DATE)
+LDFLAGS += -X $(PACKAGE)/internal/buildinfo.Number=$(VERSION)
+LDFLAGS += -X $(PACKAGE)/internal/buildinfo.GitCommit=$(GIT_COMMIT)
+LDFLAGS += -X $(PACKAGE)/internal/buildinfo.BuildDate=$(BUILD_DATE)
 
 # Default target
 all: build

--- a/internal/alertmanagerdiscover/alertmanagerdiscover_test.go
+++ b/internal/alertmanagerdiscover/alertmanagerdiscover_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func TestAlertmanagerDiscoverHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		AlertManagersFunc: func(ctx context.Context) (v1.AlertManagersResult, error) {
 			return v1.AlertManagersResult{Active: []v1.AlertManager{{URL: "http://alertmanager:9093"}}}, nil
 		},
@@ -26,7 +26,7 @@ func TestAlertmanagerDiscoverHandler_Success(t *testing.T) {
 }
 
 func TestAlertmanagerDiscoverHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		AlertManagersFunc: func(ctx context.Context) (v1.AlertManagersResult, error) {
 			return v1.AlertManagersResult{}, errors.New("api error")
 		},

--- a/internal/alertmanagerdiscover/discover.go
+++ b/internal/alertmanagerdiscover/discover.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type AlertmanagerDiscoverer interface {
@@ -12,12 +12,12 @@ type AlertmanagerDiscoverer interface {
 }
 
 // NewAlertmanagerDiscoverer returns an AlertmanagerDiscoverer backed by the provided PrometheusAPI.
-func NewAlertmanagerDiscoverer(api api.PrometheusAPI) AlertmanagerDiscoverer {
+func NewAlertmanagerDiscoverer(api promapi.PrometheusAPI) AlertmanagerDiscoverer {
 	return &alertmanagerDiscoverer{API: api}
 }
 
 type alertmanagerDiscoverer struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ AlertmanagerDiscoverer = &alertmanagerDiscoverer{}

--- a/internal/alertquery/alertquery_test.go
+++ b/internal/alertquery/alertquery_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func TestAlertQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		AlertsFunc: func(ctx context.Context) (v1.AlertsResult, error) {
 			return v1.AlertsResult{Alerts: []v1.Alert{{Labels: nil}}}, nil
 		},
@@ -26,7 +26,7 @@ func TestAlertQueryHandler_Success(t *testing.T) {
 }
 
 func TestAlertQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		AlertsFunc: func(ctx context.Context) (v1.AlertsResult, error) {
 			return v1.AlertsResult{}, errors.New("api error")
 		},

--- a/internal/alertquery/query.go
+++ b/internal/alertquery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type AlertQuerier interface {
@@ -13,12 +13,12 @@ type AlertQuerier interface {
 
 // NewAlertQuerier returns an AlertQuerier backed by the provided PrometheusAPI.
 // The concrete implementation is an *alertQuerier configured to use the given API.
-func NewAlertQuerier(api api.PrometheusAPI) AlertQuerier {
+func NewAlertQuerier(api promapi.PrometheusAPI) AlertQuerier {
 	return &alertQuerier{API: api}
 }
 
 type alertQuerier struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ AlertQuerier = &alertQuerier{}

--- a/internal/binding/binder.go
+++ b/internal/binding/binder.go
@@ -1,8 +1,8 @@
-package bindingblocks
+package binding
 
 import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type Binder interface {
@@ -10,7 +10,7 @@ type Binder interface {
 }
 
 // NewBinder returns a Binder that binds components to the given MCP server using the provided Prometheus client.
-func NewBinder(server *mcp.Server, api api.PrometheusAPI) Binder {
+func NewBinder(server *mcp.Server, api promapi.PrometheusAPI) Binder {
 	return &binder{
 		server: server,
 		api:    api,
@@ -19,7 +19,7 @@ func NewBinder(server *mcp.Server, api api.PrometheusAPI) Binder {
 
 type binder struct {
 	server *mcp.Server
-	api    api.PrometheusAPI
+	api    promapi.PrometheusAPI
 }
 
 func (b *binder) Bind() {

--- a/internal/binding/binder_test.go
+++ b/internal/binding/binder_test.go
@@ -27,7 +27,11 @@ func connectTestClient(t *testing.T, server *mcp.Server) *mcp.ClientSession {
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	t.Cleanup(func() { _ = cs.Close() })
+	t.Cleanup(func() {
+		if err := cs.Close(); err != nil {
+			t.Logf("close client session: %v", err)
+		}
+	})
 	return cs
 }
 

--- a/internal/binding/binder_test.go
+++ b/internal/binding/binder_test.go
@@ -445,3 +445,101 @@ func TestResources_ReadResourceTemplateLabelValues(t *testing.T) {
 		t.Fatalf("expected label values, got: %s", res.Contents[0].Text)
 	}
 }
+
+func TestHandleCompletion_LabelValues(t *testing.T) {
+	ctx := context.Background()
+	mock := &mock.PrometheusAPI{
+		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+			return []string{"__name__", "job", "instance"}, nil, nil
+		},
+	}
+	req := &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref: &mcp.CompleteReference{Type: "ref/resource", URI: "prom:///api/v1/label/{name}/values"},
+			Argument: mcp.CompleteParamsArgument{Name: "name", Value: "ins"},
+		},
+	}
+
+	result, err := HandleCompletion(ctx, req, mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Completion.Values) != 1 || result.Completion.Values[0] != "instance" {
+		t.Fatalf("expected [instance], got %v", result.Completion.Values)
+	}
+}
+
+func TestHandleCompletion_QueryMetricNames(t *testing.T) {
+	ctx := context.Background()
+	mock := &mock.PrometheusAPI{
+		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+			return model.LabelValues{"up", "node_cpu"}, nil, nil
+		},
+	}
+	req := &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref: &mcp.CompleteReference{Type: "ref/resource", URI: "prom:///api/v1/query?query={promql}"},
+			Argument: mcp.CompleteParamsArgument{Name: "promql", Value: "node"},
+		},
+	}
+
+	result, err := HandleCompletion(ctx, req, mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Completion.Values) != 1 || result.Completion.Values[0] != "node_cpu" {
+		t.Fatalf("expected [node_cpu], got %v", result.Completion.Values)
+	}
+}
+
+func TestHandleCompletion_Prompt(t *testing.T) {
+	ctx := context.Background()
+	mock := &mock.PrometheusAPI{
+		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+			return model.LabelValues{"up", "http_requests"}, nil, nil
+		},
+	}
+	req := &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref: &mcp.CompleteReference{Type: "ref/prompt", Name: "all-available-metrics"},
+			Argument: mcp.CompleteParamsArgument{Name: "prefix", Value: "http"},
+		},
+	}
+
+	result, err := HandleCompletion(ctx, req, mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Completion.Values) != 1 || result.Completion.Values[0] != "http_requests" {
+		t.Fatalf("expected [http_requests], got %v", result.Completion.Values)
+	}
+}
+
+func TestHandleCompletion_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	mock := &mock.PrometheusAPI{}
+	req := &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref: &mcp.CompleteReference{Type: "ref/resource", URI: "prom:///unknown"},
+			Argument: mcp.CompleteParamsArgument{Name: "x", Value: "y"},
+		},
+	}
+
+	result, err := HandleCompletion(ctx, req, mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Completion.Values) != 0 {
+		t.Fatalf("expected empty values, got %v", result.Completion.Values)
+	}
+}
+
+func TestMarshalJSON_Valid(t *testing.T) {
+	result, err := marshalJSON("test", map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "key") {
+		t.Fatalf("expected key in output, got %s", result)
+	}
+}

--- a/internal/binding/binder_test.go
+++ b/internal/binding/binder_test.go
@@ -1,4 +1,4 @@
-package bindingblocks
+package binding
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
@@ -36,7 +36,7 @@ func TestNewBinder(t *testing.T) {
 		Name:    "test",
 		Version: "1.0.0",
 	}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := NewBinder(server, mock)
 	if b == nil {
 		t.Fatal("expected non-nil binder")
@@ -48,7 +48,7 @@ func TestBind_NoPanic(t *testing.T) {
 		Name:    "test",
 		Version: "1.0.0",
 	}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := NewBinder(server, mock)
 
 	defer func() {
@@ -64,7 +64,7 @@ func TestAddResources_RegistersResources(t *testing.T) {
 		Name:    "test",
 		Version: "1.0.0",
 	}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := &binder{server: server, api: mock}
 
 	defer func() {
@@ -80,7 +80,7 @@ func TestPrompts_NoPanic(t *testing.T) {
 		Name:    "test",
 		Version: "1.0.0",
 	}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := &binder{server: server, api: mock}
 
 	defer func() {
@@ -93,7 +93,7 @@ func TestPrompts_NoPanic(t *testing.T) {
 
 func TestPrompts_AllAvailableMetrics(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"up", "node_cpu", "http_requests"}, nil, nil
 		},
@@ -123,7 +123,7 @@ func TestPrompts_AllAvailableMetrics(t *testing.T) {
 
 func TestPrompts_AllAvailableMetricsWithPrefix(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"up", "node_cpu", "node_memory", "http_requests"}, nil, nil
 		},
@@ -159,7 +159,7 @@ func TestPrompts_AllAvailableMetricsWithPrefix(t *testing.T) {
 
 func TestResources_ReadConfig(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		ConfigFunc: func(ctx context.Context) (v1.ConfigResult, error) {
 			return v1.ConfigResult{YAML: "global:\n  scrape_interval: 15s"}, nil
 		},
@@ -184,7 +184,7 @@ func TestResources_ReadConfig(t *testing.T) {
 
 func TestResources_ReadFlags(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		FlagsFunc: func(ctx context.Context) (v1.FlagsResult, error) {
 			return v1.FlagsResult{"storage.tsdb.retention.time": "15d"}, nil
 		},
@@ -209,7 +209,7 @@ func TestResources_ReadFlags(t *testing.T) {
 
 func TestResources_ReadBuildInfo(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		BuildinfoFunc: func(ctx context.Context) (v1.BuildinfoResult, error) {
 			return v1.BuildinfoResult{Version: "2.45.0", Revision: "abc123"}, nil
 		},
@@ -234,7 +234,7 @@ func TestResources_ReadBuildInfo(t *testing.T) {
 
 func TestResources_ReadResourceTemplateQuery_NoQuery(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := &binder{server: server, api: mock}
 	b.addResources()
 
@@ -249,7 +249,7 @@ func TestResources_ReadResourceTemplateQuery_NoQuery(t *testing.T) {
 
 func TestResources_ReadResourceTemplateQuery_APIFailure(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return nil, nil, errors.New("query failed")
 		},
@@ -268,7 +268,7 @@ func TestResources_ReadResourceTemplateQuery_APIFailure(t *testing.T) {
 
 func TestPrompts_AllAvailableMetricsAPIError(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -287,7 +287,7 @@ func TestPrompts_AllAvailableMetricsAPIError(t *testing.T) {
 
 func TestResources_ReadResourceTemplateLabelValues_InvalidURI(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	b := &binder{server: server, api: mock}
 	b.addResources()
 
@@ -302,7 +302,7 @@ func TestResources_ReadResourceTemplateLabelValues_InvalidURI(t *testing.T) {
 
 func TestResources_ReadResourceTemplateLabelValues_APIFailure(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -321,7 +321,7 @@ func TestResources_ReadResourceTemplateLabelValues_APIFailure(t *testing.T) {
 
 func TestResources_ReadResourceTemplateQuery(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return &model.Vector{
 				{Metric: model.Metric{"__name__": "up", "job": "test"}, Value: model.SampleValue(1), Timestamp: model.Now()},
@@ -348,7 +348,7 @@ func TestResources_ReadResourceTemplateQuery(t *testing.T) {
 
 func TestResources_ReadRuntimeInfo(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		RuntimeinfoFunc: func(ctx context.Context) (v1.RuntimeinfoResult, error) {
 			return v1.RuntimeinfoResult{CWD: "/prometheus", StartTime: time.Now()}, nil
 		},
@@ -373,7 +373,7 @@ func TestResources_ReadRuntimeInfo(t *testing.T) {
 
 func TestResources_ReadTSDBStats(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TSDBFunc: func(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
 			return v1.TSDBResult{HeadStats: v1.TSDBHeadStats{NumSeries: 100}}, nil
 		},
@@ -398,7 +398,7 @@ func TestResources_ReadTSDBStats(t *testing.T) {
 
 func TestResources_ReadWALReplayStats(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		WalReplayFunc: func(ctx context.Context) (v1.WalReplayStatus, error) {
 			return v1.WalReplayStatus{Current: 500, Max: 1000}, nil
 		},
@@ -423,7 +423,7 @@ func TestResources_ReadWALReplayStats(t *testing.T) {
 
 func TestResources_ReadResourceTemplateLabelValues(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"job1", "job2"}, nil, nil
 		},

--- a/internal/binding/completion.go
+++ b/internal/binding/completion.go
@@ -1,0 +1,88 @@
+package binding
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
+)
+
+// HandleCompletion provides autocomplete suggestions for resource URI templates
+// and prompt arguments. The MCP server calls this when the client requests
+// completion/complete for a resource template variable or prompt argument.
+func HandleCompletion(ctx context.Context, req *mcp.CompleteRequest, client promapi.PrometheusAPI) (*mcp.CompleteResult, error) {
+	val := req.Params.Argument.Value
+
+	switch req.Params.Ref.Type {
+	case "ref/resource":
+		uri := req.Params.Ref.URI
+		switch {
+		case strings.Contains(uri, "label/") && strings.Contains(uri, "/values"):
+			names, _, err := client.LabelNames(ctx, nil, time.Time{}, time.Time{})
+			if err != nil {
+				return nil, err
+			}
+			var matches []string
+			for _, n := range names {
+				if val == "" || strings.HasPrefix(n, val) {
+					matches = append(matches, n)
+				}
+			}
+			return &mcp.CompleteResult{
+				Completion: mcp.CompletionResultDetails{
+					Values:  matches,
+					HasMore: len(matches) > 20,
+					Total:   len(matches),
+				},
+			}, nil
+
+		case strings.Contains(uri, "query?query={promql}"):
+			values, _, err := client.LabelValues(ctx, "__name__", nil, time.Time{}, time.Time{})
+			if err != nil {
+				return nil, err
+			}
+			var matches []string
+			for _, v := range values {
+				s := string(v)
+				if val == "" || strings.HasPrefix(s, val) {
+					matches = append(matches, s)
+				}
+			}
+			return &mcp.CompleteResult{
+				Completion: mcp.CompletionResultDetails{
+					Values:  matches,
+					HasMore: len(matches) > 20,
+					Total:   len(matches),
+				},
+			}, nil
+		}
+
+	case "ref/prompt":
+		if req.Params.Ref.Name == "all-available-metrics" && req.Params.Argument.Name == "prefix" {
+			values, _, err := client.LabelValues(ctx, "__name__", nil, time.Time{}, time.Time{})
+			if err != nil {
+				return nil, err
+			}
+			var matches []string
+			for _, v := range values {
+				s := string(v)
+				if val == "" || strings.HasPrefix(s, val) {
+					matches = append(matches, s)
+				}
+			}
+			return &mcp.CompleteResult{
+				Completion: mcp.CompletionResultDetails{
+					Values:  matches,
+					HasMore: len(matches) > 20,
+					Total:   len(matches),
+				},
+			}, nil
+		}
+	}
+
+	return &mcp.CompleteResult{
+		Completion: mcp.CompletionResultDetails{Values: []string{}},
+	}, nil
+}

--- a/internal/binding/prompts.go
+++ b/internal/binding/prompts.go
@@ -1,4 +1,4 @@
-package bindingblocks
+package binding
 
 import (
 	"context"

--- a/internal/binding/resources.go
+++ b/internal/binding/resources.go
@@ -1,4 +1,4 @@
-package bindingblocks
+package binding
 
 import (
 	"context"

--- a/internal/binding/resources.go
+++ b/internal/binding/resources.go
@@ -52,12 +52,8 @@ func (b *binder) addStaticResources() {
 				if err != nil {
 					return "", err
 				}
-				data, err := json.MarshalIndent(result, "", "  ")
-				if err != nil {
-					return "", fmt.Errorf("marshal response: %w", err)
-				}
-				return string(data), nil
-			},
+			return marshalJSON("marshal response", result)
+		},
 		},
 		{
 			uri:         "prom:///runtime-info",
@@ -70,12 +66,8 @@ func (b *binder) addStaticResources() {
 				if err != nil {
 					return "", err
 				}
-				data, err := json.MarshalIndent(result, "", "  ")
-				if err != nil {
-					return "", fmt.Errorf("marshal response: %w", err)
-				}
-				return string(data), nil
-			},
+			return marshalJSON("marshal response", result)
+		},
 		},
 		{
 			uri:         "prom:///build-info",
@@ -88,12 +80,8 @@ func (b *binder) addStaticResources() {
 				if err != nil {
 					return "", err
 				}
-				data, err := json.MarshalIndent(result, "", "  ")
-				if err != nil {
-					return "", fmt.Errorf("marshal response: %w", err)
-				}
-				return string(data), nil
-			},
+			return marshalJSON("marshal response", result)
+		},
 		},
 		{
 			uri:         "prom:///tsdb-stats",
@@ -106,12 +94,8 @@ func (b *binder) addStaticResources() {
 				if err != nil {
 					return "", err
 				}
-				data, err := json.MarshalIndent(result, "", "  ")
-				if err != nil {
-					return "", fmt.Errorf("marshal response: %w", err)
-				}
-				return string(data), nil
-			},
+			return marshalJSON("marshal response", result)
+		},
 		},
 		{
 			uri:         "prom:///wal-replay-stats",
@@ -124,12 +108,8 @@ func (b *binder) addStaticResources() {
 				if err != nil {
 					return "", err
 				}
-				data, err := json.MarshalIndent(result, "", "  ")
-				if err != nil {
-					return "", fmt.Errorf("marshal response: %w", err)
-				}
-				return string(data), nil
-			},
+			return marshalJSON("marshal response", result)
+		},
 		},
 	}
 
@@ -245,4 +225,15 @@ func (b *binder) addResourceTemplates() {
 	})
 }
 
+// marshalJSON calls json.MarshalIndent with standard formatting and wraps
+// errors with a context prefix. The underlying types are always valid for
+// JSON serialization, so this function only exists to avoid repeating the
+// boilerplate at each call site.
+func marshalJSON(contextPrefix string, v any) (string, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", contextPrefix, err)
+	}
+	return string(data), nil
+}
 

--- a/internal/binding/tools.go
+++ b/internal/binding/tools.go
@@ -1,4 +1,4 @@
-package bindingblocks
+package binding
 
 import (
 	"encoding/json"

--- a/internal/binding/tools.go
+++ b/internal/binding/tools.go
@@ -31,6 +31,43 @@ func ptrBool(v bool) *bool {
 	return &v
 }
 
+func readOnlyTool(name, desc, title string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: desc,
+		Annotations: &mcp.ToolAnnotations{Title: title, ReadOnlyHint: true},
+	}
+}
+
+func destructiveTool(name, desc, title string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: desc,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           title,
+			DestructiveHint: ptrBool(true),
+			ReadOnlyHint:    false,
+		},
+	}
+}
+
+func idempotentTool(name, desc, title string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: desc,
+		Annotations: &mcp.ToolAnnotations{
+			Title:          title,
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func withOutputSchema(t *mcp.Tool, s any) *mcp.Tool {
+	t.OutputSchema = s
+	return t
+}
+
 // addTools makes Prometheus capabilities discoverable by LLMs as MCP tool calls.
 func (b *binder) addTools() {
 	// Expression queries accept PromQL which can be evaluated at a point in time or
@@ -38,25 +75,13 @@ func (b *binder) addTools() {
 	// oneOf for scalar, vector, and matrix shapes so LLMs can parse results.
 	{
 		expressionQuerier := expressionquery.NewExpressionQuerier(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:         "instant-query",
-			Description:  "Evaluate an instant query at a single point in time.",
-			OutputSchema: promqlSchema,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Instant Query",
-				ReadOnlyHint: true,
-			},
-		}, expressionQuerier.InstantQueryHandler)
+		mcp.AddTool(b.server, withOutputSchema(readOnlyTool(
+			"instant-query", "Evaluate an instant query at a single point in time.", "Instant Query"),
+		promqlSchema), expressionQuerier.InstantQueryHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:         "range-query",
-			Description:  "Evaluate an expression query over a range of time.",
-			OutputSchema: promqlSchema,
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Range Query",
-				ReadOnlyHint: true,
-			},
-		}, expressionQuerier.RangeQueryHandler)
+		mcp.AddTool(b.server, withOutputSchema(readOnlyTool(
+			"range-query", "Evaluate an expression query over a range of time.", "Range Query"),
+		promqlSchema), expressionQuerier.RangeQueryHandler)
 	}
 
 	// LLMs need label and series metadata to construct accurate PromQL expressions.
@@ -64,106 +89,62 @@ func (b *binder) addTools() {
 	// full queries, which helps the LLM discover metric names and label values.
 	{
 		metadataQuerier := metadataquery.NewMetadataQuerier(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "find-series-by-labels",
-			Description: "Return the list of time series that match a certain label set.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Find Series by Labels",
-				ReadOnlyHint: true,
-			},
-		}, metadataQuerier.SeriesHandler)
+		mcp.AddTool(b.server, readOnlyTool("find-series-by-labels",
+			"Return the list of time series that match a certain label set.", "Find Series by Labels",
+		), metadataQuerier.SeriesHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "list-label-names",
-			Description: "Return a list of label names.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Label Names",
-				ReadOnlyHint: true,
-			},
-		}, metadataQuerier.LabelNamesHandler)
+		mcp.AddTool(b.server, readOnlyTool("list-label-names",
+			"Return a list of label names.", "List Label Names",
+		), metadataQuerier.LabelNamesHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "list-label-values",
-			Description: "Return a list of label values for a provided label name.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Label Values",
-				ReadOnlyHint: true,
-			},
-		}, metadataQuerier.LabelValuesHandler)
+		mcp.AddTool(b.server, readOnlyTool("list-label-values",
+			"Return a list of label values for a provided label name.", "List Label Values",
+		), metadataQuerier.LabelValuesHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "target-metadata-query",
-			Description: "Return metadata about metrics currently scraped from targets.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Target Metadata Query",
-				ReadOnlyHint: true,
-			},
-		}, metadataQuerier.TargetMetadataQueryHandler)
+		mcp.AddTool(b.server, readOnlyTool("target-metadata-query",
+			"Return metadata about metrics currently scraped from targets.", "Target Metadata Query",
+		), metadataQuerier.TargetMetadataQueryHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "metric-metadata-query",
-			Description: "Return metadata about metrics currently scraped from targets. However, it does not provide any target information.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Metric Metadata Query",
-				ReadOnlyHint: true,
-			},
-		}, metadataQuerier.MetricsMetadataQueryHandler)
+		mcp.AddTool(b.server, readOnlyTool("metric-metadata-query",
+			"Return metadata about metrics currently scraped from targets. However, it does not provide any target information.", "Metric Metadata Query",
+		), metadataQuerier.MetricsMetadataQueryHandler)
 	}
 
 	// Target discovery displays scrape pool states (active/dropped) so LLMs can
 	// diagnose missing metrics without parsing raw Prometheus API responses.
 	{
 		targetDiscoverer := targetdiscover.NewTargetDiscoverer(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "target-discovery",
-			Description: "Return an overview of the current state of the Prometheus target discovery.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Target Discovery",
-				ReadOnlyHint: true,
-			},
-		}, targetDiscoverer.TargetDiscoverHandler)
+		mcp.AddTool(b.server, readOnlyTool("target-discovery",
+			"Return an overview of the current state of the Prometheus target discovery.", "Target Discovery",
+		), targetDiscoverer.TargetDiscoverHandler)
 	}
 
 	// Rule introspection helps LLMs understand what alerting and recording rules
 	// are active, enabling them to explain firing alerts and suggest threshold changes.
 	{
 		ruleQuerier := rulequery.NewRuleQuerier(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "rule-query",
-			Description: "Return a list of alerting and recording rules that are currently loaded. In addition it returns the currently active alerts fired by the Prometheus instance of each alerting rule.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Rule Query",
-				ReadOnlyHint: true,
-			},
-		}, ruleQuerier.RuleQueryHandler)
+		mcp.AddTool(b.server, readOnlyTool("rule-query",
+			"Return a list of alerting and recording rules that are currently loaded. In addition it returns the currently active alerts fired by the Prometheus instance of each alerting rule.",
+			"Rule Query",
+		), ruleQuerier.RuleQueryHandler)
 	}
 
 	// Current alerts give LLMs a snapshot of what is firing, which is useful for
 	// incident response and root-cause analysis alongside rule definitions.
 	{
 		alertQuerier := alertquery.NewAlertQuerier(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "alert-query",
-			Description: "Return a list of all active alerts.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Alert Query",
-				ReadOnlyHint: true,
-			},
-		}, alertQuerier.AlertQueryHandler)
+		mcp.AddTool(b.server, readOnlyTool("alert-query",
+			"Return a list of all active alerts.", "Alert Query",
+		), alertQuerier.AlertQueryHandler)
 	}
 
 	// Alertmanager discovery reveals which alertmanagers are reachable so LLMs can
 	// diagnose notification delivery issues.
 	{
 		alertmanagerDiscoverer := alertmanagerdiscover.NewAlertmanagerDiscoverer(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "alertmanager-discovery",
-			Description: "Return an overview of the current state of the Prometheus alertmanager discovery.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Alertmanager Discovery",
-				ReadOnlyHint: true,
-			},
-		}, alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
+		mcp.AddTool(b.server, readOnlyTool("alertmanager-discovery",
+			"Return an overview of the current state of the Prometheus alertmanager discovery.", "Alertmanager Discovery",
+		), alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
 	}
 
 
@@ -171,34 +152,20 @@ func (b *binder) addTools() {
 	// triggers the elicitation middleware to confirm before executing.
 	{
 		tsdbAdmin := tsdbadmin.NewTSDBAdmin(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "tsdb-snapshot",
-			Description: "Create a snapshot of all current data into snapshots/<datetime>-<rand> under the TSDB's data directory and returns the directory as response. It will optionally skip snapshotting data that is only present in the head block, and which has not yet been compacted to disk.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "TSDB Snapshot",
-				DestructiveHint: ptrBool(true),
-			},
-		}, tsdbAdmin.SnapshotHandler)
+		mcp.AddTool(b.server, destructiveTool("tsdb-snapshot",
+			"Create a snapshot of all current data into snapshots/<datetime>-<rand> under the TSDB's data directory and returns the directory as response. It will optionally skip snapshotting data that is only present in the head block, and which has not yet been compacted to disk.",
+			"TSDB Snapshot",
+		), tsdbAdmin.SnapshotHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "delete-series",
-			Description: "Delete data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the Clean Tombstones endpoint. Not mentioning both start and end times would clear all the data for the matched series in the database.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Delete Series",
-				DestructiveHint: ptrBool(true),
-				ReadOnlyHint:    false,
-			},
-		}, tsdbAdmin.DeleteSeriesHandler)
+		mcp.AddTool(b.server, destructiveTool("delete-series",
+			"Delete data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the Clean Tombstones endpoint. Not mentioning both start and end times would clear all the data for the matched series in the database.",
+			"Delete Series",
+		), tsdbAdmin.DeleteSeriesHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "clean-tombstones",
-			Description: "Remove the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Clean Tombstones",
-				DestructiveHint: ptrBool(true),
-				ReadOnlyHint:    false,
-			},
-		}, tsdbAdmin.CleanTombstonesHandler)
+		mcp.AddTool(b.server, destructiveTool("clean-tombstones",
+			"Remove the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space.",
+			"Clean Tombstones",
+		), tsdbAdmin.CleanTombstonesHandler)
 	}
 
 	// Reload and quit affect the running Prometheus process. The destructive hint
@@ -206,44 +173,20 @@ func (b *binder) addTools() {
 	// operations execute. Health checks are read-only and safe for repeated calls.
 	{
 		manager := manage.NewManager(b.api)
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "health-check",
-			Description: "Check Prometheus health.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Health Check",
-				ReadOnlyHint:    true,
-				IdempotentHint:  true,
-			},
-		}, manager.HealthCheckHandler)
+		mcp.AddTool(b.server, idempotentTool("health-check",
+			"Check Prometheus health.", "Health Check",
+		), manager.HealthCheckHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "readiness-check",
-			Description: "Check if Prometheus is ready to serve traffic (i.e. respond to queries).",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Readiness Check",
-				ReadOnlyHint:    true,
-				IdempotentHint:  true,
-			},
-		}, manager.ReadinessCheckHandler)
+		mcp.AddTool(b.server, idempotentTool("readiness-check",
+			"Check if Prometheus is ready to serve traffic (i.e. respond to queries).", "Readiness Check",
+		), manager.ReadinessCheckHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "reload",
-			Description: "Trigger a reload of the Prometheus configuration and rule files.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Reload",
-				DestructiveHint: ptrBool(true),
-				ReadOnlyHint:    false,
-			},
-		}, manager.ReloadHandler)
+		mcp.AddTool(b.server, destructiveTool("reload",
+			"Trigger a reload of the Prometheus configuration and rule files.", "Reload",
+		), manager.ReloadHandler)
 
-		mcp.AddTool(b.server, &mcp.Tool{
-			Name:        "quit",
-			Description: "Trigger a graceful shutdown of Prometheus.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Quit",
-				DestructiveHint: ptrBool(true),
-				ReadOnlyHint:    false,
-			},
-		}, manager.QuitHandler)
+		mcp.AddTool(b.server, destructiveTool("quit",
+			"Trigger a graceful shutdown of Prometheus.", "Quit",
+		), manager.QuitHandler)
 	}
 }

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -1,4 +1,4 @@
-package version
+package buildinfo
 
 import (
 	"bytes"

--- a/internal/buildinfo/version_test.go
+++ b/internal/buildinfo/version_test.go
@@ -1,4 +1,4 @@
-package version
+package buildinfo
 
 import (
 	"strings"

--- a/internal/elicitation/elicitation.go
+++ b/internal/elicitation/elicitation.go
@@ -1,4 +1,4 @@
-package utils
+package elicitation
 
 import (
 	"context"

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -1,4 +1,4 @@
-package utils
+package elicitation
 
 import (
 	"context"

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -16,14 +16,22 @@ func TestConfirmDestructive_ElicitNotSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
-	defer func() { _ = ss.Close() }()
+	defer func() {
+		if err := ss.Close(); err != nil {
+			t.Logf("close server session: %v", err)
+		}
+	}()
 
 	c := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0"}, nil)
 	cs, err := c.Connect(ctx, ct, nil)
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	defer func() { _ = cs.Close() }()
+	defer func() {
+		if err := cs.Close(); err != nil {
+			t.Logf("close client session: %v", err)
+		}
+	}()
 
 	confirmed, err := ConfirmDestructive(ctx, ss, "test-action", "test detail")
 	if err != nil {

--- a/internal/expressionquery/expressionquery_test.go
+++ b/internal/expressionquery/expressionquery_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
 func TestInstantQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			if query != "up" {
 				t.Fatalf("expected query 'up', got %q", query)
@@ -33,7 +33,7 @@ func TestInstantQueryHandler_Success(t *testing.T) {
 }
 
 func TestInstantQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -48,7 +48,7 @@ func TestInstantQueryHandler_APIError(t *testing.T) {
 }
 
 func TestInstantQueryHandler_WithTimeout(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			if len(opts) != 1 {
 				t.Fatalf("expected 1 option, got %d", len(opts))
@@ -67,7 +67,7 @@ func TestInstantQueryHandler_WithTimeout(t *testing.T) {
 }
 
 func TestRangeQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			if query != "up" {
 				t.Fatalf("expected query 'up', got %q", query)
@@ -94,7 +94,7 @@ func TestRangeQueryHandler_Success(t *testing.T) {
 }
 
 func TestRangeQueryHandler_WithTimeoutAndLimit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			if len(opts) != 2 {
 				t.Fatalf("expected 2 options, got %d", len(opts))
@@ -120,7 +120,7 @@ func TestRangeQueryHandler_WithTimeoutAndLimit(t *testing.T) {
 }
 
 func TestRangeQueryHandler_ZeroStep(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	q := NewExpressionQuerier(mock)
 	_, _, err := q.RangeQueryHandler(context.Background(), nil, &RangeQueryArguments{
 		Query: "up",
@@ -132,7 +132,7 @@ func TestRangeQueryHandler_ZeroStep(t *testing.T) {
 }
 
 func TestInstantQueryHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return &model.Scalar{}, nil, nil
 		},
@@ -148,7 +148,7 @@ func TestInstantQueryHandler_InvalidTime(t *testing.T) {
 }
 
 func TestRangeQueryHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return &model.Matrix{}, nil, nil
 		},
@@ -166,7 +166,7 @@ func TestRangeQueryHandler_InvalidTime(t *testing.T) {
 }
 
 func TestRangeQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},

--- a/internal/expressionquery/instant_query.go
+++ b/internal/expressionquery/instant_query.go
@@ -7,7 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -29,7 +29,7 @@ func (q *expressionQuerier) InstantQueryHandler(ctx context.Context, request *mc
 		err error
 	)
 	if input.Time != "" {
-		if ts, err = utils.ParseTime(input.Time); err != nil {
+		if ts, err = timeutil.ParseTime(input.Time); err != nil {
 			klog.InfoS("parse time", "err", err)
 		}
 	}

--- a/internal/expressionquery/query.go
+++ b/internal/expressionquery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type ExpressionQuerier interface {
@@ -14,12 +14,12 @@ type ExpressionQuerier interface {
 
 // NewExpressionQuerier creates and returns an ExpressionQuerier backed by the provided PrometheusAPI.
 // The returned implementation delegates queries to the given API.
-func NewExpressionQuerier(api api.PrometheusAPI) ExpressionQuerier {
+func NewExpressionQuerier(api promapi.PrometheusAPI) ExpressionQuerier {
 	return &expressionQuerier{API: api}
 }
 
 type expressionQuerier struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ ExpressionQuerier = &expressionQuerier{}

--- a/internal/expressionquery/range_query.go
+++ b/internal/expressionquery/range_query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -33,12 +33,12 @@ func (q *expressionQuerier) RangeQueryHandler(ctx context.Context, request *mcp.
 		err        error
 	)
 	if input.Start != "" {
-		if start, err = utils.ParseTime(input.Start); err != nil {
+		if start, err = timeutil.ParseTime(input.Start); err != nil {
 			klog.InfoS("parse start time", "err", err)
 		}
 	}
 	if input.End != "" {
-		if end, err = utils.ParseTime(input.End); err != nil {
+		if end, err = timeutil.ParseTime(input.End); err != nil {
 			klog.InfoS("parse end time", "err", err)
 		}
 	}

--- a/internal/manage/health_check.go
+++ b/internal/manage/health_check.go
@@ -8,14 +8,5 @@ import (
 )
 
 func (m *manager) HealthCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
-	result := &promapi.Result{
-		Success: true,
-	}
-
-	err := m.api.HealthCheck(ctx)
-	if err != nil {
-		result.Success = false
-		result.Message = err.Error()
-	}
-	return nil, result, nil
+	return nil, promapi.ResultOf(m.api.HealthCheck(ctx)), nil
 }

--- a/internal/manage/health_check.go
+++ b/internal/manage/health_check.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
-func (m *manager) HealthCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error) {
-	result := &ManagementResult{
+func (m *manager) HealthCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
+	result := &promapi.Result{
 		Success: true,
 	}
 

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -7,16 +7,11 @@ import (
 	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
-type ManagementResult struct {
-	Success bool   `json:"success" jsonschema:"Indicate the result of the management operation, true means success, false means failure"`
-	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`
-}
-
 type Manager interface {
-	HealthCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error)
-	ReadinessCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error)
-	ReloadHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error)
-	QuitHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error)
+	HealthCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error)
+	ReadinessCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error)
+	ReloadHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error)
+	QuitHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error)
 }
 
 type manager struct {

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type ManagementResult struct {
@@ -20,10 +20,10 @@ type Manager interface {
 }
 
 type manager struct {
-	api api.PrometheusAPI
+	api promapi.PrometheusAPI
 }
 
-func NewManager(api api.PrometheusAPI) Manager {
+func NewManager(api promapi.PrometheusAPI) Manager {
 	return &manager{api: api}
 }
 

--- a/internal/manage/manage_test.go
+++ b/internal/manage/manage_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 )
 
 func TestHealthCheckHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	m := NewManager(mock)
 	_, result, err := m.HealthCheckHandler(context.Background(), nil, struct{}{})
 	if err != nil {
@@ -21,7 +21,7 @@ func TestHealthCheckHandler_Success(t *testing.T) {
 }
 
 func TestHealthCheckHandler_Failure(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		HealthCheckFunc: func(ctx context.Context) error {
 			return errors.New("not healthy")
 		},
@@ -37,7 +37,7 @@ func TestHealthCheckHandler_Failure(t *testing.T) {
 }
 
 func TestReadinessCheckHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	m := NewManager(mock)
 	_, result, err := m.ReadinessCheckHandler(context.Background(), nil, struct{}{})
 	if err != nil {
@@ -49,7 +49,7 @@ func TestReadinessCheckHandler_Success(t *testing.T) {
 }
 
 func TestReadinessCheckHandler_Failure(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		ReadinessCheckFunc: func(ctx context.Context) error {
 			return errors.New("not ready")
 		},
@@ -65,7 +65,7 @@ func TestReadinessCheckHandler_Failure(t *testing.T) {
 }
 
 func TestReloadHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	m := NewManager(mock)
 	_, result, err := m.ReloadHandler(context.Background(), nil, struct{}{})
 	if err != nil {
@@ -77,7 +77,7 @@ func TestReloadHandler_Success(t *testing.T) {
 }
 
 func TestReloadHandler_Failure(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		ReloadFunc: func(ctx context.Context) error {
 			return errors.New("reload failed")
 		},
@@ -93,7 +93,7 @@ func TestReloadHandler_Failure(t *testing.T) {
 }
 
 func TestQuitHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	m := NewManager(mock)
 	_, result, err := m.QuitHandler(context.Background(), nil, struct{}{})
 	if err != nil {
@@ -105,7 +105,7 @@ func TestQuitHandler_Success(t *testing.T) {
 }
 
 func TestQuitHandler_Failure(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QuitFunc: func(ctx context.Context) error {
 			return errors.New("quit failed")
 		},

--- a/internal/manage/quit.go
+++ b/internal/manage/quit.go
@@ -8,8 +8,5 @@ import (
 )
 
 func (m *manager) QuitHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
-	if err := m.api.Quit(ctx); err != nil {
-		return nil, &promapi.Result{Success: false, Message: err.Error()}, nil
-	}
-	return nil, &promapi.Result{Success: true}, nil
+	return nil, promapi.ResultOf(m.api.Quit(ctx)), nil
 }

--- a/internal/manage/quit.go
+++ b/internal/manage/quit.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
-func (m *manager) QuitHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error) {
+func (m *manager) QuitHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
 	if err := m.api.Quit(ctx); err != nil {
-		return nil, &ManagementResult{Success: false, Message: err.Error()}, nil
+		return nil, &promapi.Result{Success: false, Message: err.Error()}, nil
 	}
-	return nil, &ManagementResult{Success: true}, nil
+	return nil, &promapi.Result{Success: true}, nil
 }

--- a/internal/manage/readiness_check.go
+++ b/internal/manage/readiness_check.go
@@ -8,14 +8,5 @@ import (
 )
 
 func (m *manager) ReadinessCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
-	result := &promapi.Result{
-		Success: true,
-	}
-
-	err := m.api.ReadinessCheck(ctx)
-	if err != nil {
-		result.Success = false
-		result.Message = err.Error()
-	}
-	return nil, result, nil
+	return nil, promapi.ResultOf(m.api.ReadinessCheck(ctx)), nil
 }

--- a/internal/manage/readiness_check.go
+++ b/internal/manage/readiness_check.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
-func (m *manager) ReadinessCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error) {
-	result := &ManagementResult{
+func (m *manager) ReadinessCheckHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
+	result := &promapi.Result{
 		Success: true,
 	}
 

--- a/internal/manage/reload.go
+++ b/internal/manage/reload.go
@@ -8,8 +8,5 @@ import (
 )
 
 func (m *manager) ReloadHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
-	if err := m.api.Reload(ctx); err != nil {
-		return nil, &promapi.Result{Success: false, Message: err.Error()}, nil
-	}
-	return nil, &promapi.Result{Success: true}, nil
+	return nil, promapi.ResultOf(m.api.Reload(ctx)), nil
 }

--- a/internal/manage/reload.go
+++ b/internal/manage/reload.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
-func (m *manager) ReloadHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *ManagementResult, error) {
+func (m *manager) ReloadHandler(ctx context.Context, request *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *promapi.Result, error) {
 	if err := m.api.Reload(ctx); err != nil {
-		return nil, &ManagementResult{Success: false, Message: err.Error()}, nil
+		return nil, &promapi.Result{Success: false, Message: err.Error()}, nil
 	}
-	return nil, &ManagementResult{Success: true}, nil
+	return nil, &promapi.Result{Success: true}, nil
 }

--- a/internal/metadataquery/labels.go
+++ b/internal/metadataquery/labels.go
@@ -7,7 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -36,12 +36,12 @@ func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.Ca
 		err        error
 	)
 	if input.Start != "" {
-		if start, err = utils.ParseTime(input.Start); err != nil {
+		if start, err = timeutil.ParseTime(input.Start); err != nil {
 			klog.InfoS("parse start time", "err", err)
 		}
 	}
 	if input.End != "" {
-		if end, err = utils.ParseTime(input.End); err != nil {
+		if end, err = timeutil.ParseTime(input.End); err != nil {
 			klog.InfoS("parse end time", "err", err)
 		}
 	}

--- a/internal/metadataquery/labels.go
+++ b/internal/metadataquery/labels.go
@@ -24,13 +24,6 @@ type LabelNamesResult struct {
 }
 
 func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.CallToolRequest, input *LabelNamesArguments) (*mcp.CallToolResult, *LabelNamesResult, error) {
-	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
-		if v, ok := q.cache.Get("labelnames"); ok {
-			result := v.(LabelNamesResult)
-			return nil, &result, nil
-		}
-	}
-
 	var (
 		start, end time.Time
 		err        error
@@ -65,10 +58,6 @@ func (q *metadataQuerier) LabelNamesHandler(ctx context.Context, request *mcp.Ca
 	result.LabelNames = make(model.LabelNames, len(names))
 	for i, n := range names {
 		result.LabelNames[i] = model.LabelName(n)
-	}
-
-	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
-		q.cache.Set("labelnames", *result)
 	}
 	return nil, result, nil
 }

--- a/internal/metadataquery/metadataquery_test.go
+++ b/internal/metadataquery/metadataquery_test.go
@@ -114,25 +114,6 @@ func TestLabelNamesHandler_InvalidTime(t *testing.T) {
 	}
 }
 
-func TestLabelNamesHandler_CacheHit(t *testing.T) {
-	mock := &mock.PrometheusAPI{
-		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
-			return []string{"job", "instance"}, nil, nil
-		},
-	}
-	q := NewMetadataQuerier(mock)
-	calls := 0
-	mock.LabelNamesFunc = func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
-		calls++
-		return []string{"job", "instance"}, nil, nil
-	}
-
-	_, _, _ = q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
-	_, _, _ = q.LabelNamesHandler(context.Background(), nil, &LabelNamesArguments{})
-	if calls != 1 {
-		t.Fatalf("expected 1 API call (cached), got %d", calls)
-	}
-}
 
 func TestSeriesHandler_InvalidTime(t *testing.T) {
 	mock := &mock.PrometheusAPI{
@@ -243,25 +224,6 @@ func TestLabelValuesHandler_WithTimeAndLimit(t *testing.T) {
 	}
 }
 
-func TestLabelValuesHandler_CacheHit(t *testing.T) {
-	mock := &mock.PrometheusAPI{
-		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
-			return model.LabelValues{"v1"}, nil, nil
-		},
-	}
-	q := NewMetadataQuerier(mock)
-	calls := 0
-	mock.LabelValuesFunc = func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
-		calls++
-		return model.LabelValues{"v1"}, nil, nil
-	}
-
-	_, _, _ = q.LabelValuesHandler(context.Background(), nil, &LabelValuesArguments{Label: "job"})
-	_, _, _ = q.LabelValuesHandler(context.Background(), nil, &LabelValuesArguments{Label: "job"})
-	if calls != 1 {
-		t.Fatalf("expected 1 API call (cached), got %d", calls)
-	}
-}
 
 func TestLabelValuesHandler_InvalidTime(t *testing.T) {
 	mock := &mock.PrometheusAPI{

--- a/internal/metadataquery/metadataquery_test.go
+++ b/internal/metadataquery/metadataquery_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
 func TestSeriesHandler_WithLimit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
 			if len(opts) != 1 {
 				t.Fatalf("expected 1 option, got %d", len(opts))
@@ -34,7 +34,7 @@ func TestSeriesHandler_WithLimit(t *testing.T) {
 }
 
 func TestSeriesHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
 			return []model.LabelSet{{"job": "test"}}, nil, nil
 		},
@@ -52,7 +52,7 @@ func TestSeriesHandler_Success(t *testing.T) {
 }
 
 func TestSeriesHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -67,7 +67,7 @@ func TestSeriesHandler_APIError(t *testing.T) {
 }
 
 func TestLabelNamesHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return []string{"job", "instance"}, nil, nil
 		},
@@ -83,7 +83,7 @@ func TestLabelNamesHandler_Success(t *testing.T) {
 }
 
 func TestLabelNamesHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -96,7 +96,7 @@ func TestLabelNamesHandler_APIError(t *testing.T) {
 }
 
 func TestLabelNamesHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return []string{"job"}, nil, nil
 		},
@@ -115,7 +115,7 @@ func TestLabelNamesHandler_InvalidTime(t *testing.T) {
 }
 
 func TestLabelNamesHandler_CacheHit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return []string{"job", "instance"}, nil, nil
 		},
@@ -135,7 +135,7 @@ func TestLabelNamesHandler_CacheHit(t *testing.T) {
 }
 
 func TestSeriesHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
 			return []model.LabelSet{{"job": "test"}}, nil, nil
 		},
@@ -155,7 +155,7 @@ func TestSeriesHandler_InvalidTime(t *testing.T) {
 }
 
 func TestLabelValuesHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"value1", "value2"}, nil, nil
 		},
@@ -173,7 +173,7 @@ func TestLabelValuesHandler_Success(t *testing.T) {
 }
 
 func TestSeriesHandler_WithTimeAndLimit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
 			if len(opts) != 1 {
 				t.Fatalf("expected 1 option, got %d", len(opts))
@@ -197,7 +197,7 @@ func TestSeriesHandler_WithTimeAndLimit(t *testing.T) {
 }
 
 func TestLabelNamesHandler_WithTimeAndLimit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			if len(opts) != 1 {
 				t.Fatalf("expected 1 option, got %d", len(opts))
@@ -220,7 +220,7 @@ func TestLabelNamesHandler_WithTimeAndLimit(t *testing.T) {
 }
 
 func TestLabelValuesHandler_WithTimeAndLimit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			if len(opts) != 1 {
 				t.Fatalf("expected 1 option, got %d", len(opts))
@@ -244,7 +244,7 @@ func TestLabelValuesHandler_WithTimeAndLimit(t *testing.T) {
 }
 
 func TestLabelValuesHandler_CacheHit(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"v1"}, nil, nil
 		},
@@ -264,7 +264,7 @@ func TestLabelValuesHandler_CacheHit(t *testing.T) {
 }
 
 func TestLabelValuesHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return model.LabelValues{"v1"}, nil, nil
 		},
@@ -284,7 +284,7 @@ func TestLabelValuesHandler_InvalidTime(t *testing.T) {
 }
 
 func TestLabelValuesHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -299,7 +299,7 @@ func TestLabelValuesHandler_APIError(t *testing.T) {
 }
 
 func TestTargetMetadataQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsMetadataFunc: func(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
 			return []v1.MetricMetadata{{Metric: "up", Help: "test help"}}, nil
 		},
@@ -317,7 +317,7 @@ func TestTargetMetadataQueryHandler_Success(t *testing.T) {
 }
 
 func TestTargetMetadataQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsMetadataFunc: func(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
 			return nil, errors.New("api error")
 		},
@@ -330,7 +330,7 @@ func TestTargetMetadataQueryHandler_APIError(t *testing.T) {
 }
 
 func TestMetricsMetadataQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		MetadataFunc: func(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
 			return map[string][]v1.Metadata{"up": {{Type: "counter", Help: "test"}}}, nil
 		},
@@ -348,7 +348,7 @@ func TestMetricsMetadataQueryHandler_Success(t *testing.T) {
 }
 
 func TestMetricsMetadataQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		MetadataFunc: func(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
 			return nil, errors.New("api error")
 		},

--- a/internal/metadataquery/query.go
+++ b/internal/metadataquery/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/yshngg/prometheus-mcp-server/internal/cache"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type MetadataQuerier interface {
@@ -18,7 +18,7 @@ type MetadataQuerier interface {
 	MetricsMetadataQueryHandler(ctx context.Context, request *mcp.CallToolRequest, input *MetricsMetadataQueryParams) (*mcp.CallToolResult, *MetricsMetadataQueryResult, error)
 }
 
-func NewMetadataQuerier(api api.PrometheusAPI) MetadataQuerier {
+func NewMetadataQuerier(api promapi.PrometheusAPI) MetadataQuerier {
 	return &metadataQuerier{
 		API:   api,
 		cache: cache.New(30 * time.Second),
@@ -26,7 +26,7 @@ func NewMetadataQuerier(api api.PrometheusAPI) MetadataQuerier {
 }
 
 type metadataQuerier struct {
-	API   api.PrometheusAPI
+	API   promapi.PrometheusAPI
 	cache *cache.Cache
 }
 

--- a/internal/metadataquery/query.go
+++ b/internal/metadataquery/query.go
@@ -2,10 +2,8 @@ package metadataquery
 
 import (
 	"context"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/cache"
 	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
@@ -19,15 +17,11 @@ type MetadataQuerier interface {
 }
 
 func NewMetadataQuerier(api promapi.PrometheusAPI) MetadataQuerier {
-	return &metadataQuerier{
-		API:   api,
-		cache: cache.New(30 * time.Second),
-	}
+	return &metadataQuerier{API: api}
 }
 
 type metadataQuerier struct {
-	API   promapi.PrometheusAPI
-	cache *cache.Cache
+	API promapi.PrometheusAPI
 }
 
 var _ MetadataQuerier = &metadataQuerier{}

--- a/internal/metadataquery/series.go
+++ b/internal/metadataquery/series.go
@@ -7,7 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -29,12 +29,12 @@ func (q *metadataQuerier) SeriesHandler(ctx context.Context, request *mcp.CallTo
 		err        error
 	)
 	if input.Start != "" {
-		if start, err = utils.ParseTime(input.Start); err != nil {
+		if start, err = timeutil.ParseTime(input.Start); err != nil {
 			klog.InfoS("parse start time", "err", err)
 		}
 	}
 	if input.End != "" {
-		if end, err = utils.ParseTime(input.End); err != nil {
+		if end, err = timeutil.ParseTime(input.End); err != nil {
 			klog.InfoS("parse end time", "err", err)
 		}
 	}

--- a/internal/metadataquery/values.go
+++ b/internal/metadataquery/values.go
@@ -7,7 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -38,12 +38,12 @@ func (q *metadataQuerier) LabelValuesHandler(ctx context.Context, request *mcp.C
 		err        error
 	)
 	if input.Start != "" {
-		if start, err = utils.ParseTime(input.Start); err != nil {
+		if start, err = timeutil.ParseTime(input.Start); err != nil {
 			klog.InfoS("parse start time", "err", err)
 		}
 	}
 	if input.End != "" {
-		if end, err = utils.ParseTime(input.End); err != nil {
+		if end, err = timeutil.ParseTime(input.End); err != nil {
 			klog.InfoS("parse end time", "err", err)
 		}
 	}

--- a/internal/metadataquery/values.go
+++ b/internal/metadataquery/values.go
@@ -25,14 +25,6 @@ type LabelValuesResult struct {
 }
 
 func (q *metadataQuerier) LabelValuesHandler(ctx context.Context, request *mcp.CallToolRequest, input *LabelValuesArguments) (*mcp.CallToolResult, *LabelValuesResult, error) {
-	key := "labelvalues:" + input.Label
-	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
-		if v, ok := q.cache.Get(key); ok {
-			result := v.(LabelValuesResult)
-			return nil, &result, nil
-		}
-	}
-
 	var (
 		start, end time.Time
 		err        error
@@ -64,10 +56,6 @@ func (q *metadataQuerier) LabelValuesHandler(ctx context.Context, request *mcp.C
 	)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if len(input.Match) == 0 && input.Start == "" && input.End == "" {
-		q.cache.Set(key, *result)
 	}
 	return nil, result, nil
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1,4 +1,4 @@
-package mockapi
+package mock
 
 import (
 	"context"

--- a/internal/promapi/api.go
+++ b/internal/promapi/api.go
@@ -1,4 +1,4 @@
-package api
+package promapi
 
 import (
 	"fmt"

--- a/internal/promapi/api.go
+++ b/internal/promapi/api.go
@@ -11,12 +11,12 @@ import (
 const APIVersion = "/api/v1"
 
 type PrometheusAPI interface {
-	QueryingAPI
+	v1.API
 	ManagementAPI
 }
 
 type prometheusAPI struct {
-	QueryingAPI
+	v1.API
 	ManagementAPI
 }
 
@@ -31,7 +31,7 @@ func New(addr string, client *http.Client, roundTripper http.RoundTripper) (Prom
 	}
 
 	return &prometheusAPI{
-		QueryingAPI:   v1.NewAPI(cli),
+		API:           v1.NewAPI(cli),
 		ManagementAPI: NewManagementAPI(cli),
 	}, nil
 }

--- a/internal/promapi/api_test.go
+++ b/internal/promapi/api_test.go
@@ -96,8 +96,16 @@ func TestCachingAPI_LabelNamesWithFilter(t *testing.T) {
 
 	ctx := context.Background()
 	// With match filter — should bypass cache
-	_, _, _ = caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
-	_, _, _ = caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
+	if names, _, err := caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("LabelNames: %v", err)
+	} else if len(names) == 0 {
+		t.Fatal("expected non-empty names")
+	}
+	if names, _, err := caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("LabelNames: %v", err)
+	} else if len(names) == 0 {
+		t.Fatal("expected non-empty names")
+	}
 	if inner.labelNamesCallCount != 2 {
 		t.Fatalf("expected 2 API calls (no cache with filter), got %d", inner.labelNamesCallCount)
 	}
@@ -133,8 +141,16 @@ func TestCachingAPI_LabelValues(t *testing.T) {
 	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
 
 	ctx := context.Background()
-	_, _, _ = caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{})
-	_, _, _ = caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{})
+	if values, _, err := caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("LabelValues: %v", err)
+	} else if len(values) != 1 {
+		t.Fatal("expected 1 value")
+	}
+	if values, _, err := caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("LabelValues: %v", err)
+	} else if len(values) != 1 {
+		t.Fatal("expected 1 value")
+	}
 	if calls != 1 {
 		t.Fatalf("expected 1 API call (cached), got %d", calls)
 	}

--- a/internal/promapi/api_test.go
+++ b/internal/promapi/api_test.go
@@ -1,4 +1,4 @@
-package api
+package promapi
 
 import (
 	"net/http"

--- a/internal/promapi/api_test.go
+++ b/internal/promapi/api_test.go
@@ -96,8 +96,8 @@ func TestCachingAPI_LabelNamesWithFilter(t *testing.T) {
 
 	ctx := context.Background()
 	// With match filter — should bypass cache
-	caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
-	caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
+	_, _, _ = caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
+	_, _, _ = caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
 	if inner.labelNamesCallCount != 2 {
 		t.Fatalf("expected 2 API calls (no cache with filter), got %d", inner.labelNamesCallCount)
 	}

--- a/internal/promapi/api_test.go
+++ b/internal/promapi/api_test.go
@@ -1,8 +1,14 @@
 package promapi
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 )
 
 func TestNew_InvalidAddr(t *testing.T) {
@@ -17,5 +23,197 @@ func TestNew_ValidAddr(t *testing.T) {
 	_, err := New("http://localhost:9090", http.DefaultClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type mockAPI struct {
+	PrometheusAPI
+	labelNamesCallCount int
+	LabelValuesFunc     func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error)
+}
+
+func NewMockAPI() *mockAPI {
+	return &mockAPI{labelNamesCallCount: 0}
+}
+
+func (m *mockAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+	m.labelNamesCallCount++
+	return []string{"job"}, nil, nil
+}
+
+func (m *mockAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	if m.LabelValuesFunc != nil {
+		return m.LabelValuesFunc(ctx, label, matches, startTime, endTime, opts...)
+	}
+	return nil, nil, nil
+}
+
+func (m *mockAPI) Config(ctx context.Context) (v1.ConfigResult, error) { return v1.ConfigResult{}, nil }
+func (m *mockAPI) Flags(ctx context.Context) (v1.FlagsResult, error) { return v1.FlagsResult{}, nil }
+func (m *mockAPI) HealthCheck(ctx context.Context) error { return nil }
+func (m *mockAPI) ReadinessCheck(ctx context.Context) error { return nil }
+func (m *mockAPI) Reload(ctx context.Context) error { return nil }
+func (m *mockAPI) Quit(ctx context.Context) error { return nil }
+func (m *mockAPI) Alerts(ctx context.Context) (v1.AlertsResult, error) { return v1.AlertsResult{}, nil }
+func (m *mockAPI) AlertManagers(ctx context.Context) (v1.AlertManagersResult, error) { return v1.AlertManagersResult{}, nil }
+func (m *mockAPI) Rules(ctx context.Context) (v1.RulesResult, error) { return v1.RulesResult{}, nil }
+func (m *mockAPI) Targets(ctx context.Context) (v1.TargetsResult, error) { return v1.TargetsResult{}, nil }
+func (m *mockAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) { return nil, nil }
+func (m *mockAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) { return nil, nil }
+func (m *mockAPI) CleanTombstones(ctx context.Context) error { return nil }
+func (m *mockAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error { return nil }
+func (m *mockAPI) Snapshot(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) { return v1.SnapshotResult{}, nil }
+func (m *mockAPI) TSDB(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) { return v1.TSDBResult{}, nil }
+func (m *mockAPI) WalReplay(ctx context.Context) (v1.WalReplayStatus, error) { return v1.WalReplayStatus{}, nil }
+func (m *mockAPI) Buildinfo(ctx context.Context) (v1.BuildinfoResult, error) { return v1.BuildinfoResult{}, nil }
+func (m *mockAPI) Runtimeinfo(ctx context.Context) (v1.RuntimeinfoResult, error) { return v1.RuntimeinfoResult{}, nil }
+func (m *mockAPI) Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) { return nil, nil, nil }
+func (m *mockAPI) QueryRange(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) { return nil, nil, nil }
+func (m *mockAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) { return nil, nil, nil }
+func (m *mockAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) { return nil, nil }
+
+func TestCachingAPI_LabelNames(t *testing.T) {
+	inner := NewMockAPI()
+	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
+
+	ctx := context.Background()
+	names1, _, _ := caching.LabelNames(ctx, nil, time.Time{}, time.Time{})
+	if len(names1) != 1 {
+		t.Fatal("expected 1 label name")
+	}
+	names2, _, _ := caching.LabelNames(ctx, nil, time.Time{}, time.Time{})
+	if len(names2) != 1 {
+		t.Fatal("expected 1 label name")
+	}
+	if inner.labelNamesCallCount != 1 {
+		t.Fatalf("expected 1 API call (cached), got %d", inner.labelNamesCallCount)
+	}
+}
+
+func TestCachingAPI_LabelNamesWithFilter(t *testing.T) {
+	inner := NewMockAPI()
+	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
+
+	ctx := context.Background()
+	// With match filter — should bypass cache
+	caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
+	caching.LabelNames(ctx, []string{"up"}, time.Time{}, time.Time{})
+	if inner.labelNamesCallCount != 2 {
+		t.Fatalf("expected 2 API calls (no cache with filter), got %d", inner.labelNamesCallCount)
+	}
+}
+
+func TestResultOf_Success(t *testing.T) {
+	r := ResultOf(nil)
+	if !r.Success {
+		t.Fatal("expected success")
+	}
+	if r.Message != "" {
+		t.Fatalf("expected empty message, got %s", r.Message)
+	}
+}
+
+func TestResultOf_Error(t *testing.T) {
+	r := ResultOf(errors.New("test error"))
+	if r.Success {
+		t.Fatal("expected failure")
+	}
+	if r.Message != "test error" {
+		t.Fatalf("expected 'test error', got %s", r.Message)
+	}
+}
+
+func TestCachingAPI_LabelValues(t *testing.T) {
+	calls := 0
+	inner := &mockAPI{}
+	inner.LabelValuesFunc = func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+		calls++
+		return model.LabelValues{"v1"}, nil, nil
+	}
+	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
+
+	ctx := context.Background()
+	_, _, _ = caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{})
+	_, _, _ = caching.LabelValues(ctx, "job", nil, time.Time{}, time.Time{})
+	if calls != 1 {
+		t.Fatalf("expected 1 API call (cached), got %d", calls)
+	}
+}
+
+func TestCachingAPI_PassthroughExtra(t *testing.T) {
+	inner := NewMockAPI()
+	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
+
+	ctx := context.Background()
+	if _, err := caching.Config(ctx); err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if _, err := caching.Flags(ctx); err != nil {
+		t.Fatalf("Flags: %v", err)
+	}
+	if _, err := caching.TSDB(ctx); err != nil {
+		t.Fatalf("TSDB: %v", err)
+	}
+	if _, err := caching.WalReplay(ctx); err != nil {
+		t.Fatalf("WalReplay: %v", err)
+	}
+	if _, err := caching.Buildinfo(ctx); err != nil {
+		t.Fatalf("Buildinfo: %v", err)
+	}
+	if _, err := caching.Runtimeinfo(ctx); err != nil {
+		t.Fatalf("Runtimeinfo: %v", err)
+	}
+	if _, err := caching.Snapshot(ctx, false); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if err := caching.DeleteSeries(ctx, nil, time.Time{}, time.Time{}); err != nil {
+		t.Fatalf("DeleteSeries: %v", err)
+	}
+	if _, _, err := caching.Query(ctx, "", time.Time{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if _, _, err := caching.QueryRange(ctx, "", v1.Range{}, []v1.Option{}...); err != nil {
+		t.Fatalf("QueryRange: %v", err)
+	}
+}
+
+func TestCachingAPI_Passthrough(t *testing.T) {
+	inner := NewMockAPI()
+	caching := NewCachingAPI(inner, time.Hour).(*CachingPrometheusAPI)
+
+	ctx := context.Background()
+	// Verify non-cached methods pass through without error
+	if _, err := caching.Alerts(ctx); err != nil {
+		t.Fatalf("Alerts: %v", err)
+	}
+	if _, err := caching.AlertManagers(ctx); err != nil {
+		t.Fatalf("AlertManagers: %v", err)
+	}
+	if _, err := caching.Rules(ctx); err != nil {
+		t.Fatalf("Rules: %v", err)
+	}
+	if _, err := caching.Targets(ctx); err != nil {
+		t.Fatalf("Targets: %v", err)
+	}
+	if _, err := caching.TargetsMetadata(ctx, "", "", ""); err != nil {
+		t.Fatalf("TargetsMetadata: %v", err)
+	}
+	if _, err := caching.Metadata(ctx, "", ""); err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if err := caching.CleanTombstones(ctx); err != nil {
+		t.Fatalf("CleanTombstones: %v", err)
+	}
+	if err := caching.HealthCheck(ctx); err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if err := caching.ReadinessCheck(ctx); err != nil {
+		t.Fatalf("ReadinessCheck: %v", err)
+	}
+	if err := caching.Reload(ctx); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if err := caching.Quit(ctx); err != nil {
+		t.Fatalf("Quit: %v", err)
 	}
 }

--- a/internal/promapi/cache.go
+++ b/internal/promapi/cache.go
@@ -1,0 +1,168 @@
+package promapi
+
+import (
+	"context"
+	"time"
+
+	"github.com/yshngg/prometheus-mcp-server/internal/cache"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// CachingPrometheusAPI wraps a PrometheusAPI with an in-memory TTL cache for
+// selected query methods. Uncacheable calls (with match/start/end filters) pass
+// through to the inner implementation.
+type CachingPrometheusAPI struct {
+	PrometheusAPI
+	cache *cache.Cache
+}
+
+func NewCachingAPI(inner PrometheusAPI, ttl time.Duration) PrometheusAPI {
+	return &CachingPrometheusAPI{
+		PrometheusAPI: inner,
+		cache:         cache.New(ttl),
+	}
+}
+
+func (c *CachingPrometheusAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
+	key := "labelnames"
+	if len(matches) > 0 || !startTime.IsZero() || !endTime.IsZero() {
+		return c.PrometheusAPI.LabelNames(ctx, matches, startTime, endTime, opts...)
+	}
+	if v, ok := c.cache.Get(key); ok {
+		return v.([]string), nil, nil
+	}
+	names, warnings, err := c.PrometheusAPI.LabelNames(ctx, matches, startTime, endTime, opts...)
+	if err != nil {
+		return nil, warnings, err
+	}
+	c.cache.Set(key, names)
+	return names, warnings, nil
+}
+
+func (c *CachingPrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	key := "labelvalues:" + label
+	if len(matches) > 0 || !startTime.IsZero() || !endTime.IsZero() {
+		return c.PrometheusAPI.LabelValues(ctx, label, matches, startTime, endTime, opts...)
+	}
+	if v, ok := c.cache.Get(key); ok {
+		return v.(model.LabelValues), nil, nil
+	}
+	values, warnings, err := c.PrometheusAPI.LabelValues(ctx, label, matches, startTime, endTime, opts...)
+	if err != nil {
+		return nil, warnings, err
+	}
+	c.cache.Set(key, values)
+	return values, warnings, nil
+}
+
+// Query is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+	return c.PrometheusAPI.Query(ctx, query, ts, opts...)
+}
+
+// QueryRange is uncacheable — pass through.
+func (c *CachingPrometheusAPI) QueryRange(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+	return c.PrometheusAPI.QueryRange(ctx, query, r, opts...)
+}
+
+// Series is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]model.LabelSet, v1.Warnings, error) {
+	return c.PrometheusAPI.Series(ctx, matches, startTime, endTime, opts...)
+}
+
+// QueryExemplars is uncacheable — pass through.
+func (c *CachingPrometheusAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return c.PrometheusAPI.QueryExemplars(ctx, query, startTime, endTime)
+}
+
+// Alerts is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Alerts(ctx context.Context) (v1.AlertsResult, error) {
+	return c.PrometheusAPI.Alerts(ctx)
+}
+
+// AlertManagers is uncacheable — pass through.
+func (c *CachingPrometheusAPI) AlertManagers(ctx context.Context) (v1.AlertManagersResult, error) {
+	return c.PrometheusAPI.AlertManagers(ctx)
+}
+
+// Rules is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Rules(ctx context.Context) (v1.RulesResult, error) {
+	return c.PrometheusAPI.Rules(ctx)
+}
+
+// Targets is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Targets(ctx context.Context) (v1.TargetsResult, error) {
+	return c.PrometheusAPI.Targets(ctx)
+}
+
+// TargetsMetadata is uncacheable — pass through.
+func (c *CachingPrometheusAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]v1.MetricMetadata, error) {
+	return c.PrometheusAPI.TargetsMetadata(ctx, matchTarget, metric, limit)
+}
+
+// Metadata is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	return c.PrometheusAPI.Metadata(ctx, metric, limit)
+}
+
+// TSDB is uncacheable — pass through.
+func (c *CachingPrometheusAPI) TSDB(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
+	return c.PrometheusAPI.TSDB(ctx, opts...)
+}
+
+// WalReplay is uncacheable — pass through.
+func (c *CachingPrometheusAPI) WalReplay(ctx context.Context) (v1.WalReplayStatus, error) {
+	return c.PrometheusAPI.WalReplay(ctx)
+}
+
+// Buildinfo is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Buildinfo(ctx context.Context) (v1.BuildinfoResult, error) {
+	return c.PrometheusAPI.Buildinfo(ctx)
+}
+
+// Runtimeinfo is uncacheable — pass through.
+func (c *CachingPrometheusAPI) Runtimeinfo(ctx context.Context) (v1.RuntimeinfoResult, error) {
+	return c.PrometheusAPI.Runtimeinfo(ctx)
+}
+
+func (c *CachingPrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
+	return c.PrometheusAPI.Snapshot(ctx, skipHead)
+}
+
+func (c *CachingPrometheusAPI) CleanTombstones(ctx context.Context) error {
+	return c.PrometheusAPI.CleanTombstones(ctx)
+}
+
+func (c *CachingPrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	return c.PrometheusAPI.DeleteSeries(ctx, matches, startTime, endTime)
+}
+
+func (c *CachingPrometheusAPI) Config(ctx context.Context) (v1.ConfigResult, error) {
+	return c.PrometheusAPI.Config(ctx)
+}
+
+func (c *CachingPrometheusAPI) Flags(ctx context.Context) (v1.FlagsResult, error) {
+	return c.PrometheusAPI.Flags(ctx)
+}
+
+func (c *CachingPrometheusAPI) HealthCheck(ctx context.Context) error {
+	return c.PrometheusAPI.HealthCheck(ctx)
+}
+
+func (c *CachingPrometheusAPI) ReadinessCheck(ctx context.Context) error {
+	return c.PrometheusAPI.ReadinessCheck(ctx)
+}
+
+func (c *CachingPrometheusAPI) Reload(ctx context.Context) error {
+	return c.PrometheusAPI.Reload(ctx)
+}
+
+func (c *CachingPrometheusAPI) Quit(ctx context.Context) error {
+	return c.PrometheusAPI.Quit(ctx)
+}
+
+var (
+	_ v1.API         = &CachingPrometheusAPI{}
+	_ ManagementAPI  = &CachingPrometheusAPI{}
+)

--- a/internal/promapi/cache.go
+++ b/internal/promapi/cache.go
@@ -17,6 +17,9 @@ type CachingPrometheusAPI struct {
 	cache *cache.Cache
 }
 
+// NewCachingAPI wraps a PrometheusAPI with an in-memory TTL cache for
+// LabelNames and LabelValues queries without match/start/end filters.
+// Other methods pass through to the inner implementation unchanged.
 func NewCachingAPI(inner PrometheusAPI, ttl time.Duration) PrometheusAPI {
 	return &CachingPrometheusAPI{
 		PrometheusAPI: inner,

--- a/internal/promapi/management.go
+++ b/internal/promapi/management.go
@@ -1,4 +1,4 @@
-package api
+package promapi
 
 import (
 	"context"

--- a/internal/promapi/management_test.go
+++ b/internal/promapi/management_test.go
@@ -1,4 +1,4 @@
-package api
+package promapi
 
 import (
 	"context"

--- a/internal/promapi/querying.go
+++ b/internal/promapi/querying.go
@@ -1,4 +1,4 @@
-package api
+package promapi
 
 import v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 

--- a/internal/promapi/querying.go
+++ b/internal/promapi/querying.go
@@ -1,7 +1,0 @@
-package promapi
-
-import v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-
-type QueryingAPI interface {
-	v1.API
-}

--- a/internal/promapi/types.go
+++ b/internal/promapi/types.go
@@ -11,6 +11,9 @@ type Result struct {
 // ResultOf returns a Result based on err. If err is nil, the result
 // indicates success. Otherwise, the result indicates failure with the
 // error message.
+//
+// ResultOf returns a Result based on err. If err is nil, the result
+// indicates success. Otherwise, it indicates failure with the error message.
 func ResultOf(err error) *Result {
 	if err != nil {
 		return &Result{Success: false, Message: err.Error()}

--- a/internal/promapi/types.go
+++ b/internal/promapi/types.go
@@ -7,3 +7,13 @@ type Result struct {
 	Success bool   `json:"success" jsonschema:"Indicate the result of the operation, true means success, false means failure"`
 	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`
 }
+
+// ResultOf returns a Result based on err. If err is nil, the result
+// indicates success. Otherwise, the result indicates failure with the
+// error message.
+func ResultOf(err error) *Result {
+	if err != nil {
+		return &Result{Success: false, Message: err.Error()}
+	}
+	return &Result{Success: true}
+}

--- a/internal/promapi/types.go
+++ b/internal/promapi/types.go
@@ -1,0 +1,9 @@
+package promapi
+
+// Result is a shared type for tool handlers that return a boolean success
+// status with an optional error message. Used by manage (health, readiness,
+// reload, quit) and tsdbadmin (delete-series, clean-tombstones) handlers.
+type Result struct {
+	Success bool   `json:"success" jsonschema:"Indicate the result of the operation, true means success, false means failure"`
+	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`
+}

--- a/internal/rulequery/query.go
+++ b/internal/rulequery/query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type RuleQuerier interface {
@@ -12,12 +12,12 @@ type RuleQuerier interface {
 }
 
 // NewRuleQuerier returns a RuleQuerier implementation that uses the provided PrometheusAPI to execute rule queries.
-func NewRuleQuerier(api api.PrometheusAPI) RuleQuerier {
+func NewRuleQuerier(api promapi.PrometheusAPI) RuleQuerier {
 	return &ruleQuerier{API: api}
 }
 
 type ruleQuerier struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ RuleQuerier = &ruleQuerier{}

--- a/internal/rulequery/rulequery_test.go
+++ b/internal/rulequery/rulequery_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func TestRuleQueryHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		RulesFunc: func(ctx context.Context) (v1.RulesResult, error) {
 			return v1.RulesResult{Groups: []v1.RuleGroup{{Name: "test"}}}, nil
 		},
@@ -26,7 +26,7 @@ func TestRuleQueryHandler_Success(t *testing.T) {
 }
 
 func TestRuleQueryHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		RulesFunc: func(ctx context.Context) (v1.RulesResult, error) {
 			return v1.RulesResult{}, errors.New("api error")
 		},

--- a/internal/targetdiscover/discover.go
+++ b/internal/targetdiscover/discover.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 
@@ -13,12 +13,12 @@ type TargetDiscoverer interface {
 }
 
 // NewTargetDiscoverer returns a TargetDiscoverer that uses the provided PrometheusAPI to perform target discovery.
-func NewTargetDiscoverer(api api.PrometheusAPI) TargetDiscoverer {
+func NewTargetDiscoverer(api promapi.PrometheusAPI) TargetDiscoverer {
 	return &targetDiscoverer{API: api}
 }
 
 type targetDiscoverer struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ TargetDiscoverer = &targetDiscoverer{}

--- a/internal/targetdiscover/targetdiscover_test.go
+++ b/internal/targetdiscover/targetdiscover_test.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
 func TestTargetDiscoverHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{
 				Active: []v1.ActiveTarget{
@@ -37,7 +37,7 @@ func TestTargetDiscoverHandler_Success(t *testing.T) {
 }
 
 func TestTargetDiscoverHandler_FilterByScrapePool(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{
 				Active: []v1.ActiveTarget{
@@ -60,7 +60,7 @@ func TestTargetDiscoverHandler_FilterByScrapePool(t *testing.T) {
 }
 
 func TestTargetDiscoverHandler_FilterByActive(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{
 				Active:  []v1.ActiveTarget{{Labels: model.LabelSet{"job": "test"}}},
@@ -84,7 +84,7 @@ func TestTargetDiscoverHandler_FilterByActive(t *testing.T) {
 }
 
 func TestTargetDiscoverHandler_FilterByDropped(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{
 				Active:  []v1.ActiveTarget{{Labels: model.LabelSet{"job": "test"}}},
@@ -105,7 +105,7 @@ func TestTargetDiscoverHandler_FilterByDropped(t *testing.T) {
 }
 
 func TestTargetDiscoverHandler_InvalidState(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{}, nil
 		},
@@ -120,7 +120,7 @@ func TestTargetDiscoverHandler_InvalidState(t *testing.T) {
 }
 
 func TestTargetDiscoverHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		TargetsFunc: func(ctx context.Context) (v1.TargetsResult, error) {
 			return v1.TargetsResult{}, errors.New("api error")
 		},

--- a/internal/timeutil/parse_time.go
+++ b/internal/timeutil/parse_time.go
@@ -1,4 +1,4 @@
-package utils
+package timeutil
 
 import (
 	"fmt"

--- a/internal/timeutil/parse_time_test.go
+++ b/internal/timeutil/parse_time_test.go
@@ -1,4 +1,4 @@
-package utils
+package timeutil
 
 import (
 	"testing"

--- a/internal/tsdbadmin/admin.go
+++ b/internal/tsdbadmin/admin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type TSDBAdmin interface {
@@ -14,14 +14,14 @@ type TSDBAdmin interface {
 }
 
 // NewTSDBAdmin returns a TSDBAdmin implementation that delegates Prometheus operations to the provided PrometheusAPI.
-func NewTSDBAdmin(api api.PrometheusAPI) TSDBAdmin {
+func NewTSDBAdmin(api promapi.PrometheusAPI) TSDBAdmin {
 	return &tsdbAdmin{
 		API: api,
 	}
 }
 
 type tsdbAdmin struct {
-	API api.PrometheusAPI
+	API promapi.PrometheusAPI
 }
 
 var _ TSDBAdmin = &tsdbAdmin{}

--- a/internal/tsdbadmin/admin.go
+++ b/internal/tsdbadmin/admin.go
@@ -9,8 +9,8 @@ import (
 
 type TSDBAdmin interface {
 	SnapshotHandler(ctx context.Context, request *mcp.CallToolRequest, input *SnapshotParams) (*mcp.CallToolResult, *SnapshotResult, error)
-	DeleteSeriesHandler(ctx context.Context, request *mcp.CallToolRequest, input *DeleteSeriesParams) (*mcp.CallToolResult, *DeleteSeriesResult, error)
-	CleanTombstonesHandler(ctx context.Context, request *mcp.CallToolRequest, input *CleanTombstonesParams) (*mcp.CallToolResult, *CleanTombstonesResult, error)
+	DeleteSeriesHandler(ctx context.Context, request *mcp.CallToolRequest, input *DeleteSeriesParams) (*mcp.CallToolResult, *promapi.Result, error)
+	CleanTombstonesHandler(ctx context.Context, request *mcp.CallToolRequest, input *CleanTombstonesParams) (*mcp.CallToolResult, *promapi.Result, error)
 }
 
 // NewTSDBAdmin returns a TSDBAdmin implementation that delegates Prometheus operations to the provided PrometheusAPI.

--- a/internal/tsdbadmin/clean_tombstones.go
+++ b/internal/tsdbadmin/clean_tombstones.go
@@ -10,10 +10,5 @@ import (
 type CleanTombstonesParams struct{}
 
 func (a *tsdbAdmin) CleanTombstonesHandler(ctx context.Context, request *mcp.CallToolRequest, input *CleanTombstonesParams) (*mcp.CallToolResult, *promapi.Result, error) {
-	result := &promapi.Result{Success: true}
-	if err := a.API.CleanTombstones(ctx); err != nil {
-		result.Success = false
-		result.Message = err.Error()
-	}
-	return nil, result, nil
+	return nil, promapi.ResultOf(a.API.CleanTombstones(ctx)), nil
 }

--- a/internal/tsdbadmin/clean_tombstones.go
+++ b/internal/tsdbadmin/clean_tombstones.go
@@ -4,17 +4,13 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 )
 
 type CleanTombstonesParams struct{}
 
-type CleanTombstonesResult struct {
-	Success bool   `json:"success" jsonschema:"Indicate the result of the management operation, true means success, false means failure"`
-	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`
-}
-
-func (a *tsdbAdmin) CleanTombstonesHandler(ctx context.Context, request *mcp.CallToolRequest, input *CleanTombstonesParams) (*mcp.CallToolResult, *CleanTombstonesResult, error) {
-	result := &CleanTombstonesResult{Success: true}
+func (a *tsdbAdmin) CleanTombstonesHandler(ctx context.Context, request *mcp.CallToolRequest, input *CleanTombstonesParams) (*mcp.CallToolResult, *promapi.Result, error) {
+	result := &promapi.Result{Success: true}
 	if err := a.API.CleanTombstones(ctx); err != nil {
 		result.Success = false
 		result.Message = err.Error()

--- a/internal/tsdbadmin/delete_series.go
+++ b/internal/tsdbadmin/delete_series.go
@@ -37,10 +37,5 @@ func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallTo
 		return nil, nil, fmt.Errorf("at least one match[] selector is required")
 	}
 
-	result := &promapi.Result{Success: true}
-	if err = a.API.DeleteSeries(ctx, input.Match, start, end); err != nil {
-		result.Success = false
-		result.Message = err.Error()
-	}
-	return nil, result, nil
+	return nil, promapi.ResultOf(a.API.DeleteSeries(ctx, input.Match, start, end)), nil
 }

--- a/internal/tsdbadmin/delete_series.go
+++ b/internal/tsdbadmin/delete_series.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
@@ -16,12 +17,7 @@ type DeleteSeriesParams struct {
 	End   string   `json:"end,omitzero" jsonschema:"<rfc3339 | unix_timestamp>: End timestamp. Optional and defaults to maximum possible time."`
 }
 
-type DeleteSeriesResult struct {
-	Success bool   `json:"success" jsonschema:"Indicate the result of the management operation, true means success, false means failure"`
-	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`
-}
-
-func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallToolRequest, input *DeleteSeriesParams) (*mcp.CallToolResult, *DeleteSeriesResult, error) {
+func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallToolRequest, input *DeleteSeriesParams) (*mcp.CallToolResult, *promapi.Result, error) {
 	var (
 		start, end time.Time
 		err        error
@@ -41,7 +37,7 @@ func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallTo
 		return nil, nil, fmt.Errorf("at least one match[] selector is required")
 	}
 
-	result := &DeleteSeriesResult{Success: true}
+	result := &promapi.Result{Success: true}
 	if err = a.API.DeleteSeries(ctx, input.Match, start, end); err != nil {
 		result.Success = false
 		result.Message = err.Error()

--- a/internal/tsdbadmin/delete_series.go
+++ b/internal/tsdbadmin/delete_series.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
+	"github.com/yshngg/prometheus-mcp-server/internal/timeutil"
 	"k8s.io/klog/v2"
 )
 
@@ -27,12 +27,12 @@ func (a *tsdbAdmin) DeleteSeriesHandler(ctx context.Context, request *mcp.CallTo
 		err        error
 	)
 	if input.Start != "" {
-		if start, err = utils.ParseTime(input.Start); err != nil {
+		if start, err = timeutil.ParseTime(input.Start); err != nil {
 			klog.InfoS("parse start time", "err", err)
 		}
 	}
 	if input.End != "" {
-		if end, err = utils.ParseTime(input.End); err != nil {
+		if end, err = timeutil.ParseTime(input.End); err != nil {
 			klog.InfoS("parse end time", "err", err)
 		}
 	}

--- a/internal/tsdbadmin/tsdbadmin_test.go
+++ b/internal/tsdbadmin/tsdbadmin_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func TestSnapshotHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SnapshotFunc: func(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
 			return v1.SnapshotResult{Name: "snapshot-20250101"}, nil
 		},
@@ -27,7 +27,7 @@ func TestSnapshotHandler_Success(t *testing.T) {
 }
 
 func TestSnapshotHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		SnapshotFunc: func(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
 			return v1.SnapshotResult{}, errors.New("api error")
 		},
@@ -40,7 +40,7 @@ func TestSnapshotHandler_APIError(t *testing.T) {
 }
 
 func TestDeleteSeriesHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
 			return nil
 		},
@@ -58,7 +58,7 @@ func TestDeleteSeriesHandler_Success(t *testing.T) {
 }
 
 func TestDeleteSeriesHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
 			return errors.New("api error")
 		},
@@ -76,7 +76,7 @@ func TestDeleteSeriesHandler_APIError(t *testing.T) {
 }
 
 func TestDeleteSeriesHandler_InvalidTime(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
 			return nil
 		},
@@ -96,7 +96,7 @@ func TestDeleteSeriesHandler_InvalidTime(t *testing.T) {
 }
 
 func TestDeleteSeriesHandler_WithTimeRange(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		DeleteSeriesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time) error {
 			if startTime.IsZero() || endTime.IsZero() {
 				t.Fatal("expected non-zero time range")
@@ -119,7 +119,7 @@ func TestDeleteSeriesHandler_WithTimeRange(t *testing.T) {
 }
 
 func TestDeleteSeriesHandler_NoMatch(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	a := NewTSDBAdmin(mock)
 	_, _, err := a.DeleteSeriesHandler(context.Background(), nil, &DeleteSeriesParams{})
 	if err == nil {
@@ -128,7 +128,7 @@ func TestDeleteSeriesHandler_NoMatch(t *testing.T) {
 }
 
 func TestCleanTombstonesHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		CleanTombstonesFunc: func(ctx context.Context) error {
 			return nil
 		},
@@ -144,7 +144,7 @@ func TestCleanTombstonesHandler_Success(t *testing.T) {
 }
 
 func TestCleanTombstonesHandler_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		CleanTombstonesFunc: func(ctx context.Context) error {
 			return errors.New("api error")
 		},

--- a/main.go
+++ b/main.go
@@ -17,10 +17,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/yshngg/prometheus-mcp-server/internal/bindingblocks"
-	"github.com/yshngg/prometheus-mcp-server/internal/prometheus/api"
-	"github.com/yshngg/prometheus-mcp-server/internal/utils"
-	"github.com/yshngg/prometheus-mcp-server/internal/version"
+	"github.com/yshngg/prometheus-mcp-server/internal/binding"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/elicitation"
+	"github.com/yshngg/prometheus-mcp-server/internal/buildinfo"
 	"k8s.io/klog/v2"
 )
 
@@ -125,7 +125,7 @@ func destructiveToolMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 			return next(ctx, method, req)
 		}
 
-		confirmed, err := utils.ConfirmDestructive(ctx, serverSession, params.Name,
+		confirmed, err := elicitation.ConfirmDestructive(ctx, serverSession, params.Name,
 			fmt.Sprintf("Confirm %q operation", params.Name))
 		if err != nil {
 			return next(ctx, method, req)
@@ -170,7 +170,7 @@ func main() {
 	}
 
 	if *printVersion {
-		fmt.Println(version.Info)
+		fmt.Println(buildinfo.Info)
 		klog.Flush()
 		os.Exit(0)
 	}
@@ -204,7 +204,7 @@ func main() {
 // newServer creates and configures the MCP server with all middleware,
 // tools, resources, and prompts bound to the Prometheus API client.
 // Extracted from main() so it can be tested independently.
-func newServer(promAddr string) (*mcp.Server, api.PrometheusAPI, error) {
+func newServer(promAddr string) (*mcp.Server, promapi.PrometheusAPI, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 100,
@@ -216,14 +216,14 @@ func newServer(promAddr string) (*mcp.Server, api.PrometheusAPI, error) {
 		Timeout:   30 * time.Second,
 	}
 
-	promCli, err := api.New(promAddr, httpClient, nil)
+	promCli, err := promapi.New(promAddr, httpClient, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "prometheus-mcp-server",
-		Version: string(version.Info.Number),
+		Version: string(buildinfo.Info.Number),
 	}, &mcp.ServerOptions{
 		Instructions: "You are connected to a Prometheus monitoring instance. " +
 			"Use expression queries (instant-query, range-query) to explore time-series data. " +
@@ -240,7 +240,7 @@ func newServer(promAddr string) (*mcp.Server, api.PrometheusAPI, error) {
 	server.AddReceivingMiddleware(destructiveToolMiddleware)
 	server.AddSendingMiddleware(cacheHintMiddleware)
 
-	binder := bindingblocks.NewBinder(server, promCli)
+	binder := binding.NewBinder(server, promCli)
 	binder.Bind()
 	return server, promCli, nil
 }
@@ -251,7 +251,7 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
-func readyzHandler(promCli api.PrometheusAPI) http.HandlerFunc {
+func readyzHandler(promCli promapi.PrometheusAPI) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
@@ -280,7 +280,7 @@ func authMiddleware(token string) func(http.Handler) http.Handler {
 	return auth.RequireBearerToken(verifier, nil)
 }
 
-func runHTTP(ctx context.Context, server *mcp.Server, promCli api.PrometheusAPI, addr string, authToken string) error {
+func runHTTP(ctx context.Context, server *mcp.Server, promCli promapi.PrometheusAPI, addr string, authToken string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("pong"))
@@ -319,7 +319,7 @@ func runStdio(ctx context.Context, server *mcp.Server) error {
 	return server.Run(ctx, &mcp.StdioTransport{})
 }
 
-func handleCompletion(ctx context.Context, req *mcp.CompleteRequest, promCli api.PrometheusAPI) (*mcp.CompleteResult, error) {
+func handleCompletion(ctx context.Context, req *mcp.CompleteRequest, promCli promapi.PrometheusAPI) (*mcp.CompleteResult, error) {
 	val := req.Params.Argument.Value
 
 	switch req.Params.Ref.Type {
@@ -417,7 +417,7 @@ func usageFor(fs *flag.FlagSet, short string) func() {
 		}
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "VERSION\n")
-		fmt.Fprintf(os.Stderr, "  %s\n", version.Info.Number)
+		fmt.Fprintf(os.Stderr, "  %s\n", buildinfo.Info.Number)
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func metricsMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 
 		toolName := ""
 		if req != nil {
-			if callReq, ok := req.GetParams().(*mcp.CallToolParams); ok {
+			if callReq, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok {
 				toolName = callReq.Name
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/yshngg/prometheus-mcp-server/internal/binding"
-	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
-	"github.com/yshngg/prometheus-mcp-server/internal/elicitation"
 	"github.com/yshngg/prometheus-mcp-server/internal/buildinfo"
+	"github.com/yshngg/prometheus-mcp-server/internal/elicitation"
+	"github.com/yshngg/prometheus-mcp-server/internal/promapi"
 	"k8s.io/klog/v2"
 )
 
@@ -202,7 +202,6 @@ func main() {
 
 // newServer creates and configures the MCP server with all middleware,
 // tools, resources, and prompts bound to the Prometheus API client.
-// Extracted from main() so it can be tested independently.
 func newServer(promAddr string) (*mcp.Server, promapi.PrometheusAPI, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        100,

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -233,7 +232,7 @@ func newServer(promAddr string) (*mcp.Server, promapi.PrometheusAPI, error) {
 		SchemaCache: mcp.NewSchemaCache(),
 		PageSize:    50,
 		CompletionHandler: func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
-			return handleCompletion(ctx, req, promCli)
+			return binding.HandleCompletion(ctx, req, promCli)
 		},
 	})
 	server.AddReceivingMiddleware(metricsMiddleware)
@@ -317,81 +316,6 @@ func runHTTP(ctx context.Context, server *mcp.Server, promCli promapi.Prometheus
 func runStdio(ctx context.Context, server *mcp.Server) error {
 	klog.InfoS("Listening on stdio")
 	return server.Run(ctx, &mcp.StdioTransport{})
-}
-
-func handleCompletion(ctx context.Context, req *mcp.CompleteRequest, promCli promapi.PrometheusAPI) (*mcp.CompleteResult, error) {
-	val := req.Params.Argument.Value
-
-	switch req.Params.Ref.Type {
-	case "ref/resource":
-		uri := req.Params.Ref.URI
-		switch {
-		case strings.Contains(uri, "label/") && strings.Contains(uri, "/values"):
-			names, _, err := promCli.LabelNames(ctx, nil, time.Time{}, time.Time{})
-			if err != nil {
-				return nil, err
-			}
-			var matches []string
-			for _, n := range names {
-				if val == "" || strings.HasPrefix(n, val) {
-					matches = append(matches, n)
-				}
-			}
-			return &mcp.CompleteResult{
-				Completion: mcp.CompletionResultDetails{
-					Values:  matches,
-					HasMore: len(matches) > 20,
-					Total:   len(matches),
-				},
-			}, nil
-
-		case strings.Contains(uri, "query?query={promql}"):
-			values, _, err := promCli.LabelValues(ctx, "__name__", nil, time.Time{}, time.Time{})
-			if err != nil {
-				return nil, err
-			}
-			var matches []string
-			for _, v := range values {
-				s := string(v)
-				if val == "" || strings.HasPrefix(s, val) {
-					matches = append(matches, s)
-				}
-			}
-			return &mcp.CompleteResult{
-				Completion: mcp.CompletionResultDetails{
-					Values:  matches,
-					HasMore: len(matches) > 20,
-					Total:   len(matches),
-				},
-			}, nil
-		}
-
-	case "ref/prompt":
-		if req.Params.Ref.Name == "all-available-metrics" && req.Params.Argument.Name == "prefix" {
-			values, _, err := promCli.LabelValues(ctx, "__name__", nil, time.Time{}, time.Time{})
-			if err != nil {
-				return nil, err
-			}
-			var matches []string
-			for _, v := range values {
-				s := string(v)
-				if val == "" || strings.HasPrefix(s, val) {
-					matches = append(matches, s)
-				}
-			}
-			return &mcp.CompleteResult{
-				Completion: mcp.CompletionResultDetails{
-					Values:  matches,
-					HasMore: len(matches) > 20,
-					Total:   len(matches),
-				},
-			}, nil
-		}
-	}
-
-	return &mcp.CompleteResult{
-		Completion: mcp.CompletionResultDetails{Values: []string{}},
-	}, nil
 }
 
 func usageFor(fs *flag.FlagSet, short string) func() {

--- a/main.go
+++ b/main.go
@@ -219,6 +219,7 @@ func newServer(promAddr string) (*mcp.Server, promapi.PrometheusAPI, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	promCli = promapi.NewCachingAPI(promCli, 30*time.Second)
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "prometheus-mcp-server",

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/yshngg/prometheus-mcp-server/internal/bindingblocks"
-	"github.com/yshngg/prometheus-mcp-server/internal/mockapi"
+	"github.com/yshngg/prometheus-mcp-server/internal/binding"
+	"github.com/yshngg/prometheus-mcp-server/internal/mock"
 )
 
 func TestUsageFor(t *testing.T) {
@@ -189,7 +189,7 @@ func TestHealthzHandler(t *testing.T) {
 }
 
 func TestReadyzHandler_Success(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/readyz", nil)
 	readyzHandler(mock)(w, r)
@@ -199,7 +199,7 @@ func TestReadyzHandler_Success(t *testing.T) {
 }
 
 func TestReadyzHandler_Unhealthy(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		HealthCheckFunc: func(ctx context.Context) error {
 			return errors.New("unhealthy")
 		},
@@ -295,7 +295,7 @@ func TestAuthMiddleware_MissingToken(t *testing.T) {
 }
 
 func TestHandleCompletion_ResourceLabelValues(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return []string{"__name__", "job", "instance", "namespace"}, nil, nil
 		},
@@ -323,7 +323,7 @@ func TestHandleCompletion_ResourceLabelValues(t *testing.T) {
 }
 
 func TestHandleCompletion_ResourceLabelValuesEmptyPrefix(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return []string{"__name__", "job", "instance"}, nil, nil
 		},
@@ -351,7 +351,7 @@ func TestHandleCompletion_ResourceLabelValuesEmptyPrefix(t *testing.T) {
 }
 
 func TestHandleCompletion_ResourceQueryMetricNames(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			if label == "__name__" {
 				return model.LabelValues{"up", "node_cpu_seconds_total", "http_requests_total"}, nil, nil
@@ -382,7 +382,7 @@ func TestHandleCompletion_ResourceQueryMetricNames(t *testing.T) {
 }
 
 func TestHandleCompletion_PromptMetricNames(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			if label == "__name__" {
 				return model.LabelValues{"up", "node_cpu_seconds_total", "http_requests_total"}, nil, nil
@@ -413,7 +413,7 @@ func TestHandleCompletion_PromptMetricNames(t *testing.T) {
 }
 
 func TestHandleCompletion_APIError(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelNamesFunc: func(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...v1.Option) ([]string, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -435,7 +435,7 @@ func TestHandleCompletion_APIError(t *testing.T) {
 }
 
 func TestHandleCompletion_APIErrorQuery(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		LabelValuesFunc: func(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
 			return nil, nil, errors.New("api error")
 		},
@@ -457,7 +457,7 @@ func TestHandleCompletion_APIErrorQuery(t *testing.T) {
 }
 
 func TestHandleCompletion_NonMatchingPrompt(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	req := &mcp.CompleteRequest{
 		Params: &mcp.CompleteParams{
 			Ref: &mcp.CompleteReference{
@@ -477,7 +477,7 @@ func TestHandleCompletion_NonMatchingPrompt(t *testing.T) {
 }
 
 func TestHandleCompletion_UnknownResource(t *testing.T) {
-	mock := &mockapi.PrometheusAPI{}
+	mock := &mock.PrometheusAPI{}
 	req := &mcp.CompleteRequest{
 		Params: &mcp.CompleteParams{
 			Ref: &mcp.CompleteReference{
@@ -701,8 +701,8 @@ func TestDestructiveToolMiddleware_ElicitConfirmed(t *testing.T) {
 
 func TestRunHTTP_Ping(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
-	mock := &mockapi.PrometheusAPI{}
-	binder := bindingblocks.NewBinder(server, mock)
+	mock := &mock.PrometheusAPI{}
+	binder := binding.NewBinder(server, mock)
 	binder.Bind()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -748,7 +748,7 @@ func TestRunHTTP_Ping(t *testing.T) {
 // destructive middleware does not block non-destructive tools.
 func TestEndToEnd(t *testing.T) {
 	ctx := context.Background()
-	mock := &mockapi.PrometheusAPI{
+	mock := &mock.PrometheusAPI{
 		QueryFunc: func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 			return &model.Vector{
 				{Metric: model.Metric{"__name__": "up", "job": "test"}, Value: model.SampleValue(1)},
@@ -770,7 +770,7 @@ func TestEndToEnd(t *testing.T) {
 	server.AddReceivingMiddleware(destructiveToolMiddleware)
 	server.AddSendingMiddleware(cacheHintMiddleware)
 
-	binder := bindingblocks.NewBinder(server, mock)
+	binder := binding.NewBinder(server, mock)
 	binder.Bind()
 
 	st, ct := mcp.NewInMemoryTransports()

--- a/main_test.go
+++ b/main_test.go
@@ -682,13 +682,21 @@ func TestDestructiveToolMiddleware_ElicitConfirmed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
-	defer func() { _ = ss.Close() }()
+	defer func() {
+		if err := ss.Close(); err != nil {
+			t.Logf("close server session: %v", err)
+		}
+	}()
 
 	cs, err := client.Connect(ctx, ct, nil)
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	defer func() { _ = cs.Close() }()
+	defer func() {
+		if err := cs.Close(); err != nil {
+			t.Logf("close client session: %v", err)
+		}
+	}()
 
 	_, err = cs.CallTool(ctx, &mcp.CallToolParams{Name: "delete-series"})
 	if err != nil {
@@ -784,7 +792,11 @@ func TestEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	defer func() { _ = cs.Close() }()
+	defer func() {
+		if err := cs.Close(); err != nil {
+			t.Logf("close client session: %v", err)
+		}
+	}()
 
 	// ListTools
 	toolsResult, err := cs.ListTools(ctx, nil)
@@ -878,7 +890,9 @@ func captureStderr(t *testing.T, fn func()) string {
 
 	fn()
 
-	_ = w.Close()
+	if err := w.Close(); err != nil {
+		t.Logf("close pipe: %v", err)
+	}
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(r); err != nil {
 		t.Fatalf("read: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -313,7 +313,7 @@ func TestHandleCompletion_ResourceLabelValues(t *testing.T) {
 		},
 	}
 
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestHandleCompletion_ResourceLabelValuesEmptyPrefix(t *testing.T) {
 		},
 	}
 
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestHandleCompletion_ResourceQueryMetricNames(t *testing.T) {
 		},
 	}
 
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestHandleCompletion_PromptMetricNames(t *testing.T) {
 		},
 	}
 
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestHandleCompletion_APIError(t *testing.T) {
 		},
 	}
 
-	_, err := handleCompletion(context.Background(), req, mock)
+	_, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err == nil {
 		t.Fatal("expected error from API failure")
 	}
@@ -450,7 +450,7 @@ func TestHandleCompletion_APIErrorQuery(t *testing.T) {
 		},
 	}
 
-	_, err := handleCompletion(context.Background(), req, mock)
+	_, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err == nil {
 		t.Fatal("expected error from API failure")
 	}
@@ -467,7 +467,7 @@ func TestHandleCompletion_NonMatchingPrompt(t *testing.T) {
 			Argument: mcp.CompleteParamsArgument{Name: "x", Value: "y"},
 		},
 	}
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -491,7 +491,7 @@ func TestHandleCompletion_UnknownResource(t *testing.T) {
 		},
 	}
 
-	result, err := handleCompletion(context.Background(), req, mock)
+	result, err := binding.HandleCompletion(context.Background(), req, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
### Summary

Restructured internal directory, applied design patterns, fixed bugs, improved test quality. 51 files changed, +1075 / −712.

### Directory restructuring

| Before | After | Reason |
|---|---|---|
| `internal/prometheus/api/` | `internal/promapi/` | Flatten nested dir |
| `internal/bindingblocks/` | `internal/binding/` | Shorter, avoids SDK name conflict |
| `internal/utils/` (mixed concerns) | `internal/timeutil/` + `internal/elicitation/` | Split unrelated functions |
| `internal/mockapi/` | `internal/mock/` | Shorter |
| `internal/version/` | `internal/buildinfo/` | More descriptive |

### Design patterns applied

| Pattern | Where | Impact |
|---|---|---|
| **Null Object** | `promapi.ResultOf(err)` | 6 handlers simplified — consistent error handling |
| **Builder** | `readOnlyTool()` / `destructiveTool()` / `idempotentTool()` | 18 tool definitions, ~70 fewer lines |
| **Decorator** | `CachingPrometheusAPI` | Caching extracted from metadataquery → transparent wrapper |
| **Marshal helper** | `marshalJSON()` | 5 identical blocks consolidated |

### Code quality

- `handleCompletion` moved from `main.go` → `internal/binding/completion.go` (boundary cleanup)
- `MetricsMiddleware` bug fixed: `CallToolParams` → `CallToolParamsRaw` (tool names now properly tracked)
- `querying.go` removed (thin wrapper, inlined `v1.API` directly into `PrometheusAPI`)
- All `_ = .Close()` calls replaced with `t.Logf` error logging (errcheck + idiomatic)
- All exported functions documented (`HandleCompletion`, `NewCachingAPI`, `ResultOf`)
- Test assertions checked instead of `_, _, _ =` discard

### Testing
`go build` ✓ | `go vet` ✓ | `go test` ✓ 15/15 packages | **80.1% coverage**