### PR TITLE
fix: rename MCP tools from hyphens to underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ Your client must then include `Authorization: Bearer my-token` in requests to `/
 
 ## Tools
 
-**Expression:** `instant-query`, `range-query`
+**Expression:** `instant_query`, `range_query`
 
-**Metadata:** `find-series-by-labels`, `list-label-names`, `list-label-values`, `target-metadata-query`, `metric-metadata-query`
+**Metadata:** `find_series_by_labels`, `list_label_names`, `list_label_values`, `target_metadata_query`, `metric_metadata_query`
 
-**Discovery:** `target-discovery`, `alert-query`, `rule-query`, `alertmanager-discovery`
+**Discovery:** `target_discovery`, `alert_query`, `rule_query`, `alertmanager_discovery`
 
-**TSDB Admin:** `tsdb-snapshot`, `delete-series`, `clean-tombstones`
+**TSDB Admin:** `tsdb_snapshot`, `delete_series`, `clean_tombstones`
 
-**Management:** `health-check`, `readiness-check`, `reload`, `quit`
+**Management:** `health_check`, `readiness_check`, `reload`, `quit`
 
 ## Resources
 

--- a/internal/binding/resources.go
+++ b/internal/binding/resources.go
@@ -142,7 +142,7 @@ func (b *binder) addStaticResources() {
 func (b *binder) addResourceTemplates() {
 	b.server.AddResourceTemplate(&mcp.ResourceTemplate{
 		URITemplate: "prom:///api/v1/query?query={promql}",
-		Name:        "instant-query",
+		Name:        "instant_query",
 		Title:       "Prometheus Instant Query",
 		Description: "Result of an instant Prometheus query. Replace {promql} with a URL-encoded PromQL expression. Use prometheus time format for timestamps.",
 		MIMEType:    "application/json",

--- a/internal/binding/tools.go
+++ b/internal/binding/tools.go
@@ -76,11 +76,11 @@ func (b *binder) addTools() {
 	{
 		expressionQuerier := expressionquery.NewExpressionQuerier(b.api)
 		mcp.AddTool(b.server, withOutputSchema(readOnlyTool(
-			"instant-query", "Evaluate an instant query at a single point in time.", "Instant Query"),
+			"instant_query", "Evaluate an instant query at a single point in time.", "Instant Query"),
 		promqlSchema), expressionQuerier.InstantQueryHandler)
 
 		mcp.AddTool(b.server, withOutputSchema(readOnlyTool(
-			"range-query", "Evaluate an expression query over a range of time.", "Range Query"),
+			"range_query", "Evaluate an expression query over a range of time.", "Range Query"),
 		promqlSchema), expressionQuerier.RangeQueryHandler)
 	}
 
@@ -89,23 +89,23 @@ func (b *binder) addTools() {
 	// full queries, which helps the LLM discover metric names and label values.
 	{
 		metadataQuerier := metadataquery.NewMetadataQuerier(b.api)
-		mcp.AddTool(b.server, readOnlyTool("find-series-by-labels",
+		mcp.AddTool(b.server, readOnlyTool("find_series_by_labels",
 			"Return the list of time series that match a certain label set.", "Find Series by Labels",
 		), metadataQuerier.SeriesHandler)
 
-		mcp.AddTool(b.server, readOnlyTool("list-label-names",
+		mcp.AddTool(b.server, readOnlyTool("list_label_names",
 			"Return a list of label names.", "List Label Names",
 		), metadataQuerier.LabelNamesHandler)
 
-		mcp.AddTool(b.server, readOnlyTool("list-label-values",
+		mcp.AddTool(b.server, readOnlyTool("list_label_values",
 			"Return a list of label values for a provided label name.", "List Label Values",
 		), metadataQuerier.LabelValuesHandler)
 
-		mcp.AddTool(b.server, readOnlyTool("target-metadata-query",
+		mcp.AddTool(b.server, readOnlyTool("target_metadata_query",
 			"Return metadata about metrics currently scraped from targets.", "Target Metadata Query",
 		), metadataQuerier.TargetMetadataQueryHandler)
 
-		mcp.AddTool(b.server, readOnlyTool("metric-metadata-query",
+		mcp.AddTool(b.server, readOnlyTool("metric_metadata_query",
 			"Return metadata about metrics currently scraped from targets. However, it does not provide any target information.", "Metric Metadata Query",
 		), metadataQuerier.MetricsMetadataQueryHandler)
 	}
@@ -114,7 +114,7 @@ func (b *binder) addTools() {
 	// diagnose missing metrics without parsing raw Prometheus API responses.
 	{
 		targetDiscoverer := targetdiscover.NewTargetDiscoverer(b.api)
-		mcp.AddTool(b.server, readOnlyTool("target-discovery",
+		mcp.AddTool(b.server, readOnlyTool("target_discovery",
 			"Return an overview of the current state of the Prometheus target discovery.", "Target Discovery",
 		), targetDiscoverer.TargetDiscoverHandler)
 	}
@@ -123,7 +123,7 @@ func (b *binder) addTools() {
 	// are active, enabling them to explain firing alerts and suggest threshold changes.
 	{
 		ruleQuerier := rulequery.NewRuleQuerier(b.api)
-		mcp.AddTool(b.server, readOnlyTool("rule-query",
+		mcp.AddTool(b.server, readOnlyTool("rule_query",
 			"Return a list of alerting and recording rules that are currently loaded. In addition it returns the currently active alerts fired by the Prometheus instance of each alerting rule.",
 			"Rule Query",
 		), ruleQuerier.RuleQueryHandler)
@@ -133,7 +133,7 @@ func (b *binder) addTools() {
 	// incident response and root-cause analysis alongside rule definitions.
 	{
 		alertQuerier := alertquery.NewAlertQuerier(b.api)
-		mcp.AddTool(b.server, readOnlyTool("alert-query",
+		mcp.AddTool(b.server, readOnlyTool("alert_query",
 			"Return a list of all active alerts.", "Alert Query",
 		), alertQuerier.AlertQueryHandler)
 	}
@@ -142,7 +142,7 @@ func (b *binder) addTools() {
 	// diagnose notification delivery issues.
 	{
 		alertmanagerDiscoverer := alertmanagerdiscover.NewAlertmanagerDiscoverer(b.api)
-		mcp.AddTool(b.server, readOnlyTool("alertmanager-discovery",
+		mcp.AddTool(b.server, readOnlyTool("alertmanager_discovery",
 			"Return an overview of the current state of the Prometheus alertmanager discovery.", "Alertmanager Discovery",
 		), alertmanagerDiscoverer.AlertmanagerDiscoverHandler)
 	}
@@ -152,17 +152,17 @@ func (b *binder) addTools() {
 	// triggers the elicitation middleware to confirm before executing.
 	{
 		tsdbAdmin := tsdbadmin.NewTSDBAdmin(b.api)
-		mcp.AddTool(b.server, destructiveTool("tsdb-snapshot",
+		mcp.AddTool(b.server, destructiveTool("tsdb_snapshot",
 			"Create a snapshot of all current data into snapshots/<datetime>-<rand> under the TSDB's data directory and returns the directory as response. It will optionally skip snapshotting data that is only present in the head block, and which has not yet been compacted to disk.",
 			"TSDB Snapshot",
 		), tsdbAdmin.SnapshotHandler)
 
-		mcp.AddTool(b.server, destructiveTool("delete-series",
+		mcp.AddTool(b.server, destructiveTool("delete_series",
 			"Delete data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the Clean Tombstones endpoint. Not mentioning both start and end times would clear all the data for the matched series in the database.",
 			"Delete Series",
 		), tsdbAdmin.DeleteSeriesHandler)
 
-		mcp.AddTool(b.server, destructiveTool("clean-tombstones",
+		mcp.AddTool(b.server, destructiveTool("clean_tombstones",
 			"Remove the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space.",
 			"Clean Tombstones",
 		), tsdbAdmin.CleanTombstonesHandler)
@@ -173,11 +173,11 @@ func (b *binder) addTools() {
 	// operations execute. Health checks are read-only and safe for repeated calls.
 	{
 		manager := manage.NewManager(b.api)
-		mcp.AddTool(b.server, idempotentTool("health-check",
+		mcp.AddTool(b.server, idempotentTool("health_check",
 			"Check Prometheus health.", "Health Check",
 		), manager.HealthCheckHandler)
 
-		mcp.AddTool(b.server, idempotentTool("readiness-check",
+		mcp.AddTool(b.server, idempotentTool("readiness_check",
 			"Check if Prometheus is ready to serve traffic (i.e. respond to queries).", "Readiness Check",
 		), manager.ReadinessCheckHandler)
 

--- a/internal/promapi/types.go
+++ b/internal/promapi/types.go
@@ -2,7 +2,7 @@ package promapi
 
 // Result is a shared type for tool handlers that return a boolean success
 // status with an optional error message. Used by manage (health, readiness,
-// reload, quit) and tsdbadmin (delete-series, clean-tombstones) handlers.
+// reload, quit) and tsdbadmin (delete_series, clean_tombstones) handlers.
 type Result struct {
 	Success bool   `json:"success" jsonschema:"Indicate the result of the operation, true means success, false means failure"`
 	Message string `json:"message,omitempty" jsonschema:"Explanation message when the operation fails."`

--- a/main.go
+++ b/main.go
@@ -101,8 +101,8 @@ func metricsMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 }
 
 var destructiveTools = map[string]bool{
-	"delete-series":    true,
-	"clean-tombstones": true,
+	"delete_series":    true,
+	"clean_tombstones": true,
 	"reload":           true,
 	"quit":             true,
 }
@@ -225,10 +225,10 @@ func newServer(promAddr string) (*mcp.Server, promapi.PrometheusAPI, error) {
 		Version: string(buildinfo.Info.Number),
 	}, &mcp.ServerOptions{
 		Instructions: "You are connected to a Prometheus monitoring instance. " +
-			"Use expression queries (instant-query, range-query) to explore time-series data. " +
-			"Use metadata tools (list-label-names, list-label-values, find-series-by-labels) to discover available metrics and labels. " +
+			"Use expression queries (instant_query, range_query) to explore time-series data. " +
+			"Use metadata tools (list_label_names, list_label_values, find_series_by_labels) to discover available metrics and labels. " +
 			"Resources are available at prom:/// URIs (e.g., prom:///config, prom:///api/v1/query?query=up) for direct data access. " +
-			"Use management tools (health-check, readiness-check, reload, quit) with caution as quit and reload affect server operation.",
+			"Use management tools (health_check, readiness_check, reload, quit) with caution as quit and reload affect server operation.",
 		SchemaCache: mcp.NewSchemaCache(),
 		PageSize:    50,
 		CompletionHandler: func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -117,7 +117,7 @@ func TestMetricsMiddleware_WithRequest(t *testing.T) {
 	mw := metricsMiddleware(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 		return nil, nil
 	})
-	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant-query"}}
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant_query"}}
 	_, err := mw(context.Background(), methodCallTool, req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -128,7 +128,7 @@ func TestMetricsMiddleware_WithRequestError(t *testing.T) {
 	mw := metricsMiddleware(func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 		return nil, errors.New("handler error")
 	})
-	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant-query"}}
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant_query"}}
 	_, err := mw(context.Background(), methodCallTool, req)
 	if err == nil {
 		t.Fatal("expected error")
@@ -589,7 +589,7 @@ func TestDestructiveToolMiddleware_NonDestructiveTool(t *testing.T) {
 		called = true
 		return nil, nil
 	})
-	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant-query"}}
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "instant_query"}}
 	_, err := mw(context.Background(), methodCallTool, req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -605,7 +605,7 @@ func TestDestructiveToolMiddleware_NilSession(t *testing.T) {
 		called = true
 		return nil, nil
 	})
-	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "delete-series"}}
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "delete_series"}}
 	_, err := mw(context.Background(), methodCallTool, req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -665,7 +665,7 @@ func TestDestructiveToolMiddleware_ElicitConfirmed(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "1.0"}, nil)
 	server.AddReceivingMiddleware(destructiveToolMiddleware)
 	var handlerCalled bool
-	mcp.AddTool(server, &mcp.Tool{Name: "delete-series"}, func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+	mcp.AddTool(server, &mcp.Tool{Name: "delete_series"}, func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
 		handlerCalled = true
 		return &mcp.CallToolResult{}, nil, nil
 	})
@@ -698,7 +698,7 @@ func TestDestructiveToolMiddleware_ElicitConfirmed(t *testing.T) {
 		}
 	}()
 
-	_, err = cs.CallTool(ctx, &mcp.CallToolParams{Name: "delete-series"})
+	_, err = cs.CallTool(ctx, &mcp.CallToolParams{Name: "delete_series"})
 	if err != nil {
 		t.Fatalf("call tool: %v", err)
 	}
@@ -809,33 +809,33 @@ func TestEndToEnd(t *testing.T) {
 
 	// CallTool — instant query
 	callResult, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name: "instant-query",
+		Name: "instant_query",
 		Arguments: map[string]any{"query": "up"},
 	})
 	if err != nil {
-		t.Fatalf("call tool instant-query: %v", err)
+		t.Fatalf("call tool instant_query: %v", err)
 	}
 	if callResult.IsError {
-		t.Fatal("expected instant-query to succeed")
+		t.Fatal("expected instant_query to succeed")
 	}
 
 	// CallTool — non-destructive tool passes through middleware
-	healthResult, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "health-check"})
+	healthResult, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "health_check"})
 	if err != nil {
-		t.Fatalf("call tool health-check: %v", err)
+		t.Fatalf("call tool health_check: %v", err)
 	}
 	if healthResult.IsError {
-		t.Fatal("expected health-check to succeed")
+		t.Fatal("expected health_check to succeed")
 	}
 
 	// CallTool — destructive tool with no client elicitation support
 	// should fall through (ConfirmDestructive returns (true, nil) on error)
-	delResult, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "delete-series", Arguments: map[string]any{"match[]": []string{"up"}}})
+	delResult, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "delete_series", Arguments: map[string]any{"match[]": []string{"up"}}})
 	if err != nil {
-		t.Fatalf("call tool delete-series: %v", err)
+		t.Fatalf("call tool delete_series: %v", err)
 	}
 	if delResult.IsError {
-		t.Fatal("expected delete-series to fall through when elicitation unsupported")
+		t.Fatal("expected delete_series to fall through when elicitation unsupported")
 	}
 
 	// ListResources


### PR DESCRIPTION
## Problem

The Prometheus MCP server registers tools with hyphenated names (e.g., `list-label-names`), but LLMs consistently call them with underscores (`list_label_names`). The MCP SDK does exact-match dispatch, so these calls fail with "invalid tool."

<img width="2560" height="340" alt="Screenshot From 2026-07-12 09-53-24" src="https://github.com/user-attachments/assets/aa28b367-1f89-43c9-a78b-71ba1d50a3ec" />

## Root Cause

MCP spec SEP-986 (accepted, final) explicitly allows both `_` and `-` in tool names. LLMs naturally produce underscores, but the server only registered hyphenated names.

## Fix

Renamed all 16 tool names from hyphens to underscores in `internal/binding/tools.go`, plus updated all references in:

- `main.go` — destructiveTools map keys + server Instructions string
- `main_test.go` — test params and error messages
- `README.md` — Tools section
- `internal/binding/resources.go` — resource template name
- `internal/promapi/types.go` — comment

## No Breaking Changes

Purely a string rename in the MCP tool registration — handler logic, Prometheus API calls, and all internal code are unchanged.