### PR TITLE
fix: keep only the -v flag for klog

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,12 +148,26 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
+func initKlogFlags(fs *flag.FlagSet) {
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	_ = klogFlags.Set("legacy_stderr_threshold_behavior", "false")
+	_ = klogFlags.Set("stderrthreshold", "INFO")
+	klogFlags.VisitAll(func(f *flag.Flag) {
+		if f.Name == "v" {
+			fs.Var(f.Value, f.Name, f.Usage)
+		}
+	})
+}
+
 func main() {
 	klog.LogToStderr(true)
 	defer klog.Flush()
 
 	fs := flag.NewFlagSet("prometheus-mcp-server", flag.ExitOnError)
-	klog.InitFlags(fs)
+
+	initKlogFlags(fs)
+
 	var (
 		promAddr      = fs.String("prom-addr", envOrDefault("PROM_ADDR", "http://localhost:9090/"), "The address of the Prometheus to connect to.")
 		mcpAddr       = fs.String("mcp-addr", envOrDefault("MCP_ADDR", "localhost:8080"), "The address of the MCP server to listen on.")

--- a/main_test.go
+++ b/main_test.go
@@ -878,6 +878,21 @@ func TestEndToEnd(t *testing.T) {
 	}
 }
 
+func TestInitKlogFlags_OnlyVForwarded(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	initKlogFlags(fs)
+
+	if v := fs.Lookup("v"); v == nil {
+		t.Fatal("expected -v flag to be registered")
+	}
+
+	for _, name := range []string{"vmodule", "logtostderr", "alsologtostderr", "stderrthreshold", "log_dir", "log_file", "add_dir_header", "skip_log_headers", "one_output"} {
+		if f := fs.Lookup(name); f != nil {
+			t.Fatalf("unexpected flag -%s registered", name)
+		}
+	}
+}
+
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()


### PR DESCRIPTION
Changes  to register klog flags into a private flag set instead, then forwards only the  (verbosity) flag to the main flag set. All other klog flags are hidden from the user.

Closes #135